### PR TITLE
fix(mise): explicitly set Python precompiled flavor

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -8,33 +8,8 @@ backend = "pipx:pre-commit"
 version = "3.14.3"
 backend = "core:python"
 
-[tools.python."platforms.linux-arm64"]
-checksum = "sha256:89e2cfba1b1ca974a8d2b7aa054d8c32a9301b1168fde2bf1c9a5270488c018f"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260310/cpython-3.14.3+20260310-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-
-[tools.python."platforms.linux-arm64-musl"]
-checksum = "sha256:89e2cfba1b1ca974a8d2b7aa054d8c32a9301b1168fde2bf1c9a5270488c018f"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260310/cpython-3.14.3+20260310-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-
-[tools.python."platforms.linux-x64"]
-checksum = "sha256:0023aa5e9930a70585e1b639055f4928f76080b2e1dcc2458453b595155a50ee"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260310/cpython-3.14.3+20260310-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-
-[tools.python."platforms.linux-x64-musl"]
-checksum = "sha256:0023aa5e9930a70585e1b639055f4928f76080b2e1dcc2458453b595155a50ee"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260310/cpython-3.14.3+20260310-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-
-[tools.python."platforms.macos-arm64"]
-checksum = "sha256:1a98bbe7e63547d2f764bc9119f6d604dfb333f21afab5f4885dc362b4f3a921"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260310/cpython-3.14.3+20260310-aarch64-apple-darwin-install_only_stripped.tar.gz"
-
-[tools.python."platforms.macos-x64"]
-checksum = "sha256:a974fefb14c2b724ca87830240d36fc865780391ec9e1e2db28a1d5f58f5fae2"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260310/cpython-3.14.3+20260310-x86_64-apple-darwin-install_only_stripped.tar.gz"
-
-[tools.python."platforms.windows-x64"]
-checksum = "sha256:8458fdf45b9b47685a7dea76d72a4b8cf946091fe48cac43d3564f7f318e8c0f"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260310/cpython-3.14.3+20260310-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+[tools.python.options]
+precompiled_flavor = "install_only_stripped"
 
 [[tools.uv]]
 version = "0.10.4"

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,8 @@ uv = "latest"
 [settings]
 # Auto-create and activate a .venv managed by uv.
 python.uv_venv_auto = "create|source"
+# Use standard (non-freethreaded) Python build to match Home Assistant.
+python.precompiled_flavor = "install_only_stripped"
 
 [env]
 # Ensure uv uses the mise-managed Python interpreter, not a system one.


### PR DESCRIPTION
## Summary

- Explicitly set `python.precompiled_flavor = "install_only_stripped"` in mise.toml
- Ensures mise downloads the standard (non-freethreaded) Python build to match Home Assistant

## Context

CI was failing because mise was downloading the freethreaded Python variant (`cpython-3.14.3+...-freethreaded-install_only_stripped.tar.gz`) which has a missing `lib` directory issue. Home Assistant uses standard GIL-enabled Python, not the freethreaded variant.