### PR TITLE
revert: remove precompiled_flavor setting to fix freethreaded selection

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -8,8 +8,33 @@ backend = "pipx:pre-commit"
 version = "3.14.3"
 backend = "core:python"
 
-[tools.python.options]
-precompiled_flavor = "install_only_stripped"
+[tools.python."platforms.linux-arm64"]
+checksum = "sha256:c4a5cc7681da3ed2066194f6fac24207a764db38f23fc5a2b1b56671ee3142d6"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+
+[tools.python."platforms.linux-arm64-musl"]
+checksum = "sha256:c4a5cc7681da3ed2066194f6fac24207a764db38f23fc5a2b1b56671ee3142d6"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+
+[tools.python."platforms.linux-x64"]
+checksum = "sha256:bc35984c271adb7b0d2f730eced89fbbb96246c4d716c415e4af7ed686627831"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+
+[tools.python."platforms.linux-x64-musl"]
+checksum = "sha256:bc35984c271adb7b0d2f730eced89fbbb96246c4d716c415e4af7ed686627831"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+
+[tools.python."platforms.macos-arm64"]
+checksum = "sha256:f9b4a94d2d62ca77e08873b861b8cd989eda922ad3c3eafd2dfad57375e6ae61"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-aarch64-apple-darwin-install_only_stripped.tar.gz"
+
+[tools.python."platforms.macos-x64"]
+checksum = "sha256:cb8d27660e0575d33c6828c4f73c891a005d8cfade8941d889fd0efd0ff031dc"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-apple-darwin-install_only_stripped.tar.gz"
+
+[tools.python."platforms.windows-x64"]
+checksum = "sha256:2223000d2dcce0f50a8feddb8a8391ec6e5534f6f7169e10004a11ce9b438ed3"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260320/cpython-3.14.3+20260320-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
 
 [[tools.uv]]
 version = "0.10.4"

--- a/mise.toml
+++ b/mise.toml
@@ -8,8 +8,6 @@ uv = "latest"
 [settings]
 # Auto-create and activate a .venv managed by uv.
 python.uv_venv_auto = "create|source"
-# Use standard (non-freethreaded) Python build to match Home Assistant.
-python.precompiled_flavor = "install_only_stripped"
 
 [env]
 # Ensure uv uses the mise-managed Python interpreter, not a system one.


### PR DESCRIPTION
## Summary

- Removes `python.precompiled_flavor = "install_only_stripped"` setting from mise.toml
- Regenerates mise.lock with correct non-freethreaded Python URLs

## Context

PR #18 added an explicit `precompiled_flavor` setting to avoid freethreaded Python builds. However, mise 2026.3.10 has a bug where setting **any** `precompiled_flavor` value causes mise to include freethreaded builds in the selection pool, and they win alphabetically because "freethreaded" comes before the non-freethreaded variant.

mise 2026.3.10 correctly excludes freethreaded builds by default when **no** `precompiled_flavor` is set. Removing the explicit setting allows mise's default behavior to work correctly.

## Technical Details

The bug is in mise's `fetch_precompiled_for_target` function:
```rust
.filter(|v| flavor.is_some() || !v.contains("freethreaded"))
```

This logic means:
- When `flavor` is `None` → exclude freethreaded builds ✅
- When `flavor` is `Some(_)` → include all builds (including freethreaded) ❌

The fix should check if the flavor itself contains "freethreaded", not just whether any flavor is set.

Reverts: #18