### PR TITLE
docs: address design review gaps and add open questions Q015-Q019

### DIFF
--- a/custom_components/hamster/__init__.py
+++ b/custom_components/hamster/__init__.py
@@ -8,7 +8,6 @@ components by looking for custom_components/<domain>/__init__.py.
 
 # TODO: uncomment once hamster.component has real entry points
 # from hamster.component import (
-#     async_setup,
 #     async_setup_entry,
 #     async_unload_entry,
 # )

--- a/docs/src/project/implementation-plan.md
+++ b/docs/src/project/implementation-plan.md
@@ -604,11 +604,13 @@ message and `is_error=True`.
 - Case-insensitive matching.
 - Domain filter restricts results.
 - No match -> "no results" message.
+- Empty index + any query -> "no results" message.
 
 **`explain()`:**
 
 - Known service -> raw HA description with fields, selectors, target.
 - Unknown service -> `None`.
+- Empty index + any domain/service -> `None`.
 - Service with sections (nested field groups) -> fields shown flattened.
 
 **Selector descriptions:**
@@ -626,6 +628,10 @@ message and `is_error=True`.
   correct domain, service, target, data.
 - `hamster_services_call` with unknown service -> `Done` with
   `is_error=True`.
+- `hamster_services_search` with empty index -> `Done` with "no results"
+  text.
+- `hamster_services_call` with empty index -> `Done` with
+  `is_error=True` (service not in index).
 - `hamster_services_schema` -> `Done` with selector description.
 - Unknown tool name -> `ValueError`.
 
@@ -871,7 +877,10 @@ no mocks.  The entire protocol is testable with plain data.
 - Wrong `Content-Type` -> `SendResponse(415)`.
 - `Content-Type` with parameters (e.g. `application/json; charset=utf-8`)
   -> accepted.
-- Missing `Accept` -> `SendResponse(406)`.
+- `Accept` header absent (`accept=None`) -> `SendResponse(406)`.
+- `Accept` header empty string (`accept=""`) -> `SendResponse(406)`.
+- `Accept: text/html` (present but incompatible) -> `SendResponse(406)`.
+- `Accept: application/json` -> accepted.
 - `Accept: */*` -> accepted.
 - `Accept: application/*` -> accepted.
 - Malformed JSON body -> `SendResponse(400)` with `PARSE_ERROR`.

--- a/docs/src/project/mcp-protocol.md
+++ b/docs/src/project/mcp-protocol.md
@@ -47,6 +47,15 @@ The client must initialize before any other operation:
 | `tools/list` | Client → Server | List available tools (paginated via cursor) |
 | `tools/call` | Client → Server | Invoke a tool by name with arguments |
 
+### Utility Methods
+
+| Method | Direction | Purpose |
+| --- | --- | --- |
+| `ping` | Client → Server | Liveness check; returns `{"result": {}}` |
+
+`ping` is handled in all session states (IDLE, INITIALIZING, ACTIVE).
+In CLOSED state, it returns a JSON-RPC error.
+
 ### Errors
 
 Two levels of error reporting:

--- a/docs/src/project/open-questions.md
+++ b/docs/src/project/open-questions.md
@@ -174,3 +174,166 @@ incomplete --- the implementation should include a comment noting this.
 
 **Leaning toward:** Defer both.  Add `AudioContent` when a use case
 emerges.  `EmbeddedResource` deferred longer.
+
+## Q015: Content-Type Parameter Stripping Responsibility
+
+**Question:** Should the sans-IO core defensively strip Content-Type
+parameters (e.g. `; charset=utf-8`), or trust the transport to normalize
+the header before building `IncomingRequest`?
+
+**Context:** Stage 5 says the core ignores Content-Type parameters ---
+only the media type portion is checked.  Stage 6 notes that aiohttp's
+`request.content_type` already strips parameters before the core sees
+them.  This means the core's parameter-stripping logic is dead code in
+production (aiohttp never passes parameters through), but it is
+exercised in Stage 5's pure tests which construct `IncomingRequest`
+values directly.
+
+Options:
+
+1. Core strips parameters defensively (defense-in-depth, testable in
+   isolation, correct if a different transport doesn't strip).
+2. Core requires pre-normalized media type (simpler core, transport
+   contract is explicit).
+
+**Leaning toward:** Option 1 --- core strips defensively.  The cost is
+negligible and it avoids a hidden contract between transport and core.
+
+## Q016: Batch Request Containing `initialize` --- Error Format
+
+**Question:** When an `initialize` message appears inside a JSON-RPC
+batch array, what is the exact error response?
+
+**Context:** Stage 5 says "`initialize` MUST NOT appear in a batch" and
+the test says `SendResponse(400)`.  But there are multiple possible
+behaviors:
+
+1. Reject the entire batch with HTTP 400 before processing any messages.
+2. Process other messages normally and return a per-item JSON-RPC error
+   for the `initialize` message.
+3. Return a single JSON-RPC error response (not an array) for the whole
+   batch.
+
+Session creation mid-batch creates ambiguity: subsequent messages in the
+same batch would lack a session ID context.  Option 2 would require
+processing other messages either with no session or with the
+newly-created session, both of which are problematic.
+
+**Leaning toward:** Option 1 --- reject the entire batch with HTTP 400
+and a JSON-RPC `INVALID_REQUEST` error body.  This is the simplest
+behavior and avoids ambiguity about session state for other messages in
+the batch.
+
+## Q017: `call_tool()` Error Mechanism for Unknown Tool Name
+
+**Question:** Should `call_tool()` raise `ValueError` for unknown tool
+names, or return `Done(CallToolResult(is_error=True))`?
+
+**Context:** Currently `call_tool()` raises `ValueError` for unknown
+tool names (implementation plan Stage 4, line 568).  `MCPServerSession`
+must catch this and convert it to `SessionError(INVALID_PARAMS)` (Stage
+5, line 732).  This creates an implicit contract between `call_tool()`
+and the session: exception-based control flow for a predictable case.
+
+`call_tool()` already returns `Done(CallToolResult(is_error=True))` for
+"service not found in index" --- a similar "not found" condition.  Using
+the same pattern for "unknown tool name" would be consistent.
+
+Options:
+
+1. Keep `ValueError` --- treats unknown tool name as a programming error
+   (the session should only pass known names).  The session's tool-name
+   validation is the real guard.
+2. Return `Done(is_error=True)` --- treats it as a data error,
+   consistent with "service not found".  Removes exception-based control
+   flow.
+3. Return a dedicated `ToolNotFound` effect type --- more explicit, but
+   adds a type for a case that should rarely occur.
+
+**No strong leaning yet.**  Option 1 is defensible if the session always
+validates first.  Option 2 is simpler and more consistent.
+
+## Q018: `ServerCapabilities` Type Structure
+
+**Question:** Should `ServerCapabilities` model the `tools` capability
+as a `bool` or as a proper dataclass that can express sub-capabilities
+like `listChanged`?
+
+**Context:** The current design uses `ServerCapabilities(tools: bool =
+True)`, serialized as `{"tools": {}}`.  MCP allows richer capability
+declarations:
+
+```json
+{"capabilities": {"tools": {"listChanged": true}}}
+```
+
+The `bool` representation cannot express `listChanged`.  When SSE
+support lands (Q012), the server would need `listChanged: true` to tell
+clients they can subscribe to tool list change notifications.  At that
+point, `ServerCapabilities` would need to change from `tools: bool` to
+something richer --- a breaking change for any code constructing it.
+
+Options:
+
+1. Keep `tools: bool` --- accept the future refactor when SSE lands.
+   Simpler now.
+2. Model properly now with a `ToolsCapability` dataclass:
+
+   ```python
+   @dataclass(frozen=True)
+   class ToolsCapability:
+       list_changed: bool = False
+
+   @dataclass(frozen=True)
+   class ServerCapabilities:
+       tools: ToolsCapability | None = field(
+           default_factory=ToolsCapability,
+       )
+   ```
+
+   Serialization: `tools=ToolsCapability(list_changed=False)` ->
+   `{"tools": {}}`.  `tools=ToolsCapability(list_changed=True)` ->
+   `{"tools": {"listChanged": true}}`.  `tools=None` -> `{}`.
+
+**Leaning toward:** Option 2 --- trivial extra work now, avoids a
+breaking change later, and honestly represents the protocol's structure.
+
+## Q019: Logging Strategy
+
+**Question:** Should the project define a logging strategy as part of
+the design, or leave it as implementation guidance?
+
+**Context:** The design documents logging in exactly one place:
+`HamsterEffectHandler` logs unexpected exceptions via
+`_LOGGER.exception()` (Stage 8).  There is no broader guidance for
+session lifecycle events, index rebuilds, request handling, or auditing.
+
+In production, operators need visibility into:
+
+- Whether clients are connecting (session created/expired).
+- Whether the service index is populated (index rebuilt, service count).
+- What services the LLM is invoking (tool call audit trail).
+- Client errors that might indicate misconfiguration (bad headers,
+  unknown sessions).
+
+Options:
+
+1. Define formal log points in the implementation plan (specific log
+   statements at specific locations with specific levels).
+2. Add implementation guidance (recommended log levels and categories,
+   not prescriptive statements).
+3. Leave to implementer discretion.
+
+Recommended log levels if guidance is added:
+
+- **INFO**: session created, session expired, index rebuilt (with service
+  count).
+- **DEBUG**: individual request handling, tool call arguments/results.
+- **WARNING**: client errors (bad headers, unknown sessions, rejected
+  requests).
+- **ERROR**: unexpected failures only (e.g. `HamsterEffectHandler`
+  catch-all).
+
+**Leaning toward:** Option 2 --- add implementation guidance with the
+log level recommendations above.  Formal log-point specs are too rigid;
+implementer discretion with no guidance risks inconsistency.


### PR DESCRIPTION
## Summary

- Fix four documentation inconsistencies found during design review
- Add five new open questions (Q015-Q019) for pending design decisions

## Fixes

| Fix | File | Change |
|-----|------|--------|
| F1 | `custom_components/hamster/__init__.py` | Remove `async_setup` from commented import block — integration is `single_config_entry: true` |
| F2 | `docs/src/project/implementation-plan.md` | Expand Accept header test cases from 3 to 6 (absent, empty, incompatible, `application/json`, `*/*`, `application/*`) |
| F3 | `docs/src/project/mcp-protocol.md` | Add `ping` utility method section — was handled in implementation plan but undocumented in protocol page |
| F4 | `docs/src/project/implementation-plan.md` | Add 4 empty-`ServiceIndex` test cases across `search()`, `explain()`, and `call_tool()` |

## New Open Questions

| Question | Topic | Leaning |
|----------|-------|---------|
| Q015 | Content-Type parameter stripping responsibility | Core strips defensively |
| Q016 | Batch request containing `initialize` — error format | Reject entire batch with HTTP 400 |
| Q017 | `call_tool()` error mechanism for unknown tool name | No strong leaning |
| Q018 | `ServerCapabilities` type structure | Model properly now with `ToolsCapability` dataclass |
| Q019 | Logging strategy | Implementation guidance with recommended log levels |