### PR TITLE
Add automatic CI retries to merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,7 @@ queue_rules:
       - "#approved-reviews-by >= 1"
     merge_method: merge
     checks_timeout: 90 min
+    max_checks_retries: 2
 
 merge_queue:
   max_parallel_checks: 1


### PR DESCRIPTION
## Summary

- Add `max_checks_retries: 2` to the Mergify queue rule, enabling automatic CI retries before dequeuing a PR
- This gives 3 total CI attempts (1 initial + 2 retries), helping handle flaky CI

Reference: https://docs.mergify.com/changelog/2026-03-18-automatic-ci-retries-in-merge-queue/