### PR TITLE
Point manifest.json requirements to GitHub main

### DIFF
--- a/custom_components/hamster/manifest.json
+++ b/custom_components/hamster/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/altendky/hamster/issues",
-  "requirements": ["hamster>=0.0.1"],
+  "requirements": ["hamster@git+https://github.com/altendky/hamster.git@main"],
   "single_config_entry": true,
   "version": "0.0.1"
 }


### PR DESCRIPTION
## Summary

- Install hamster package directly from GitHub main branch instead of PyPI

This allows users to test the integration immediately without waiting for PyPI publication. Home Assistant will pip-install the package directly from the main branch when the custom component is loaded.

## References

- Refs #30 - Documents local testing setup
- Refs #31 - Design permanent local testing workflow