### PR TITLE
Remove hamster_ prefix from tool names

### DIFF
--- a/docs/src/project/decisions.md
+++ b/docs/src/project/decisions.md
@@ -563,13 +563,16 @@ instance).  It accurately represents that these are core HA commands.
 
 ## D030: Tool Renaming for Multi-Source Architecture
 
-**Decision:** Rename tools from `hamster_services_*` to `hamster_*` with
+**Decision:** Rename tools from `hamster_services_*` to generic names with
 path-based addressing:
 
-- `hamster_services_search` → `hamster_search`
-- `hamster_services_explain` → `hamster_explain`
-- `hamster_services_call` → `hamster_call`
-- `hamster_services_schema` → `hamster_schema`
+- `hamster_services_search` → `search`
+- `hamster_services_explain` → `explain`
+- `hamster_services_call` → `call`
+- `hamster_services_schema` → `schema`
+
+MCP clients prefix tool names with the server name ("hamster"), so clients
+see these as `hamster_search`, `hamster_explain`, etc.
 
 **Rationale:** The multi-source architecture (D024) uses a unified
 `<group>/<path>` addressing scheme.  Generic tool names with path
@@ -592,10 +595,10 @@ base class allows groups to be implemented independently without
 inheritance coupling.  The method set covers the four operations needed
 by the MCP tools:
 
-- `search()` for `hamster_search`
-- `explain()` for `hamster_explain`
-- `schema()` for `hamster_schema`
-- `has_command()` + `parse_call_args()` for `hamster_call`
+- `search()` for `search`
+- `explain()` for `explain`
+- `schema()` for `schema`
+- `has_command()` + `parse_call_args()` for `call`
 
 The `available` property (default `True`) allows groups like `supervisor`
 to indicate they are unavailable on certain installations.

--- a/docs/src/project/implementation-plan.md
+++ b/docs/src/project/implementation-plan.md
@@ -1739,19 +1739,21 @@ On success, returns `ServiceCall(domain, service, target, data, continuation)`.
 
 ## Stage 11 --- Tool Generalization
 
-Rename tools from `hamster_services_*` to `hamster_*` with path-based
-addressing.
+Rename tools from `hamster_services_*` to generic names with path-based
+addressing. MCP clients prefix tool names with the server name ("hamster"),
+so tools are named `search`, `explain`, `call`, `schema` (appearing as
+`hamster_search`, etc. to clients).
 
 ### Renamed tool definitions
 
 | Old Name | New Name | Changes |
 | --- | --- | --- |
-| `hamster_services_search` | `hamster_search` | Add optional `path_filter` parameter |
-| `hamster_services_explain` | `hamster_explain` | Replace `domain`+`service` with `path` |
-| `hamster_services_call` | `hamster_call` | Replace `domain`+`service` with `path` |
-| `hamster_services_schema` | `hamster_schema` | Replace `selector_type` with `path` (group-aware) |
+| `hamster_services_search` | `search` | Add optional `path_filter` parameter |
+| `hamster_services_explain` | `explain` | Replace `domain`+`service` with `path` |
+| `hamster_services_call` | `call` | Replace `domain`+`service` with `path` |
+| `hamster_services_schema` | `schema` | Replace `selector_type` with `path` (group-aware) |
 
-**`hamster_search`:**
+**`search`:**
 
 | Property | Type | Required |
 | --- | --- | --- |
@@ -1761,7 +1763,7 @@ addressing.
 Description: "Search for commands across all groups.  Use path_filter to
 narrow scope (e.g., `services`, `services/light`, `hass/config`)."
 
-**`hamster_explain`:**
+**`explain`:**
 
 | Property | Type | Required |
 | --- | --- | --- |
@@ -1770,7 +1772,7 @@ narrow scope (e.g., `services`, `services/light`, `hass/config`)."
 Description: "Get detailed description of a command.  Path format:
 `group/command` (e.g., `services/light.turn_on`, `hass/get_states`)."
 
-**`hamster_call`:**
+**`call`:**
 
 | Property | Type | Required |
 | --- | --- | --- |
@@ -1785,7 +1787,7 @@ Note: The `target`/`data` split for services moves into how
 The MCP tool interface becomes uniform; each group parses arguments its
 own way.
 
-**`hamster_schema`:**
+**`schema`:**
 
 | Property | Type | Required |
 | --- | --- | --- |
@@ -1820,25 +1822,25 @@ rationale.
 | Condition | Behavior |
 | --- | --- |
 | Unknown tool name | Return `Done(is_error=True)` with error message |
-| `hamster_search` missing `query` | Return `Done(is_error=True)` |
-| `hamster_search` with non-string `query` | Return `Done(is_error=True)` |
-| `hamster_explain` missing `path` | Return `Done(is_error=True)` |
-| `hamster_explain` with path not containing `/` | Return `Done(is_error=True)` |
-| `hamster_explain` with unknown group | Return `Done(is_error=True)` |
-| `hamster_explain` with unknown command | Return `Done(is_error=True)` |
-| `hamster_call` missing `path` | Return `Done(is_error=True)` |
-| `hamster_call` with `arguments` not an object | Return `Done(is_error=True)` |
-| `hamster_schema` missing `path` | Return `Done(is_error=True)` |
+| `search` missing `query` | Return `Done(is_error=True)` |
+| `search` with non-string `query` | Return `Done(is_error=True)` |
+| `explain` missing `path` | Return `Done(is_error=True)` |
+| `explain` with path not containing `/` | Return `Done(is_error=True)` |
+| `explain` with unknown group | Return `Done(is_error=True)` |
+| `explain` with unknown command | Return `Done(is_error=True)` |
+| `call` missing `path` | Return `Done(is_error=True)` |
+| `call` with `arguments` not an object | Return `Done(is_error=True)` |
+| `schema` missing `path` | Return `Done(is_error=True)` |
 
 ### Tests --- `_tests/test_tools.py` (updated)
 
 **Tool definitions:**
 
 - `TOOLS` has exactly 4 entries.
-- Tool names are `hamster_search`, `hamster_explain`, `hamster_call`, `hamster_schema`.
+- Tool names are `search`, `explain`, `call`, `schema`.
 - Each tool has valid `input_schema`.
 
-**`hamster_search`:**
+**`search`:**
 
 - With no filter, searches all groups.
 - With `path_filter="services"`, searches only services.
@@ -1848,7 +1850,7 @@ rationale.
 - Non-string `query` returns `Done(is_error=True)`.
 - Non-string `path_filter` returns `Done(is_error=True)`.
 
-**`hamster_explain`:**
+**`explain`:**
 
 - `"services/light.turn_on"` returns service description.
 - `"hass/get_states"` returns hass command description.
@@ -1858,7 +1860,7 @@ rationale.
 - Missing `path` returns `Done(is_error=True)`.
 - Non-string `path` returns `Done(is_error=True)`.
 
-**`hamster_call`:**
+**`call`:**
 
 - `"services/light.turn_on"` with valid args returns `ServiceCall` effect.
 - `"hass/get_states"` with valid args returns `HassCommand` effect.
@@ -1868,7 +1870,7 @@ rationale.
 - `arguments` as string returns `Done(is_error=True)`.
 - Missing `arguments` defaults to `{}`.
 
-**`hamster_schema`:**
+**`schema`:**
 
 - `"services/selector/duration"` returns selector description.
 - `"hass/get_states"` returns hass command schema.

--- a/src/hamster/component/_tests/test_http.py
+++ b/src/hamster/component/_tests/test_http.py
@@ -163,7 +163,7 @@ class TestFullMCPFlow:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_search",
+                    "name": "search",
                     "arguments": {"query": "light"},
                 },
             ),
@@ -217,7 +217,7 @@ class TestFullMCPFlow:
                 json=_make_jsonrpc(
                     "tools/call",
                     {
-                        "name": "hamster_call",
+                        "name": "call",
                         "arguments": {
                             "path": "services/light.turn_on",
                             "arguments": {
@@ -250,7 +250,7 @@ class TestFullMCPFlow:
         self,
         http_client: TestClient[web.Request, web.Application],
     ) -> None:
-        """Test hamster_explain tool."""
+        """Test explain tool."""
         session_id = await _init_session(http_client)
 
         resp = await http_client.post(
@@ -258,7 +258,7 @@ class TestFullMCPFlow:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_explain",
+                    "name": "explain",
                     "arguments": {"path": "services/light.turn_on"},
                 },
             ),
@@ -278,7 +278,7 @@ class TestFullMCPFlow:
         self,
         http_client: TestClient[web.Request, web.Application],
     ) -> None:
-        """Test hamster_schema tool."""
+        """Test schema tool."""
         session_id = await _init_session(http_client)
 
         resp = await http_client.post(
@@ -286,7 +286,7 @@ class TestFullMCPFlow:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_schema",
+                    "name": "schema",
                     "arguments": {"path": "services/selector/boolean"},
                 },
             ),

--- a/src/hamster/mcp/_core/tools.py
+++ b/src/hamster/mcp/_core/tools.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 TOOLS: tuple[Tool, ...] = (
     Tool(
-        name="hamster_search",
+        name="search",
         description=(
             "Search for commands across all groups. Use path_filter to narrow "
             "scope (e.g., 'services', 'services/light', 'hass/config')."
@@ -58,7 +58,7 @@ TOOLS: tuple[Tool, ...] = (
         },
     ),
     Tool(
-        name="hamster_explain",
+        name="explain",
         description=(
             "Get detailed description of a command. Path format: "
             "group/command (e.g., 'services/light.turn_on', 'hass/get_states')."
@@ -78,7 +78,7 @@ TOOLS: tuple[Tool, ...] = (
         },
     ),
     Tool(
-        name="hamster_call",
+        name="call",
         description=(
             "Execute a command. Path format: group/command. "
             "Arguments are command-specific."
@@ -102,7 +102,7 @@ TOOLS: tuple[Tool, ...] = (
         },
     ),
     Tool(
-        name="hamster_schema",
+        name="schema",
         description=(
             "Get schema/type information for a command or type. "
             "For services, use 'services/selector/TYPE' "
@@ -153,7 +153,7 @@ def call_tool(
     """Dispatch a tool call by name.
 
     Args:
-        name: Tool name (hamster_search, hamster_explain, hamster_call, hamster_schema)
+        name: Tool name (search, explain, call, schema)
         arguments: Tool arguments
         registry: Group registry with registered source groups
         user_id: Authenticated user ID for authorization
@@ -161,19 +161,19 @@ def call_tool(
     Returns:
         ToolEffect (Done for immediate results, effect for I/O)
     """
-    if name == "hamster_search":
+    if name == "search":
         return _call_search(arguments, registry)
-    if name == "hamster_explain":
+    if name == "explain":
         return _call_explain(arguments, registry)
-    if name == "hamster_call":
+    if name == "call":
         return _call_call(arguments, registry, user_id)
-    if name == "hamster_schema":
+    if name == "schema":
         return _call_schema(arguments, registry)
     return _make_error(f"Unknown tool: {name}")
 
 
 def _call_search(arguments: dict[str, object], registry: GroupRegistry) -> ToolEffect:
-    """Handle hamster_search."""
+    """Handle search tool."""
     query = arguments.get("query")
     if not isinstance(query, str):
         return _make_error("Missing or invalid 'query' parameter (must be a string)")
@@ -187,7 +187,7 @@ def _call_search(arguments: dict[str, object], registry: GroupRegistry) -> ToolE
 
 
 def _call_explain(arguments: dict[str, object], registry: GroupRegistry) -> ToolEffect:
-    """Handle hamster_explain."""
+    """Handle explain tool."""
     path = arguments.get("path")
     if not isinstance(path, str):
         return _make_error("Missing or invalid 'path' parameter (must be a string)")
@@ -211,7 +211,7 @@ def _call_explain(arguments: dict[str, object], registry: GroupRegistry) -> Tool
 def _call_call(
     arguments: dict[str, object], registry: GroupRegistry, user_id: str | None
 ) -> ToolEffect:
-    """Handle hamster_call."""
+    """Handle call tool."""
     path = arguments.get("path")
     if not isinstance(path, str):
         return _make_error("Missing or invalid 'path' parameter (must be a string)")
@@ -236,7 +236,7 @@ def _call_call(
 
 
 def _call_schema(arguments: dict[str, object], registry: GroupRegistry) -> ToolEffect:
-    """Handle hamster_schema."""
+    """Handle schema tool."""
     path = arguments.get("path")
     if not isinstance(path, str):
         return _make_error("Missing or invalid 'path' parameter (must be a string)")

--- a/src/hamster/mcp/_tests/test_aiohttp.py
+++ b/src/hamster/mcp/_tests/test_aiohttp.py
@@ -249,15 +249,15 @@ class TestCompleteFlow:
         tools = data["result"]["tools"]
         assert len(tools) == 4
         tool_names = {t["name"] for t in tools}
-        assert "hamster_call" in tool_names
+        assert "call" in tool_names
 
-        # tools/call - hamster_search (no I/O)
+        # tools/call - search (no I/O)
         resp = await client.post(
             "/mcp",
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_search",
+                    "name": "search",
                     "arguments": {"query": "light"},
                 },
             ),
@@ -273,13 +273,13 @@ class TestCompleteFlow:
         assert len(content) == 1
         assert "light" in content[0]["text"].lower()
 
-        # tools/call - hamster_call (with I/O)
+        # tools/call - call (with I/O)
         resp = await client.post(
             "/mcp",
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "services/light.turn_on",
                         "arguments": {
@@ -359,13 +359,13 @@ class TestEffectDispatch:
         """Done effect returns result immediately without I/O."""
         session_id = await _init_session(client)
 
-        # hamster_search returns Done immediately
+        # search returns Done immediately
         resp = await client.post(
             "/mcp",
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_search",
+                    "name": "search",
                     "arguments": {"query": "light"},
                 },
             ),
@@ -393,7 +393,7 @@ class TestEffectDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "services/light.turn_on",
                         "arguments": {},
@@ -427,7 +427,7 @@ class TestEffectDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "services/light.turn_on",
                         "arguments": {},
@@ -495,7 +495,7 @@ class TestBatchRequests:
             _make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {"path": "services/light.turn_on", "arguments": {}},
                 },
                 request_id=1,
@@ -503,7 +503,7 @@ class TestBatchRequests:
             _make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {"path": "services/light.turn_off", "arguments": {}},
                 },
                 request_id=2,
@@ -796,7 +796,7 @@ class TestSupervisorCallDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "supervisor/core/info",
                         "arguments": {},
@@ -829,7 +829,7 @@ class TestSupervisorCallDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "supervisor/core/logs",
                         "arguments": {},
@@ -860,7 +860,7 @@ class TestSupervisorCallDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "supervisor/addons/{slug}/info",
                         "arguments": {"slug": "my_addon"},
@@ -894,7 +894,7 @@ class TestSupervisorCallDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "supervisor/core/info",
                         "arguments": {},
@@ -933,7 +933,7 @@ class TestSupervisorCallDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "supervisor/core/logs",
                         "arguments": {},
@@ -968,7 +968,7 @@ class TestSupervisorCallDispatch:
             json=_make_jsonrpc(
                 "tools/call",
                 {
-                    "name": "hamster_call",
+                    "name": "call",
                     "arguments": {
                         "path": "supervisor/core/info",
                         "arguments": {},

--- a/src/hamster/mcp/_tests/test_session.py
+++ b/src/hamster/mcp/_tests/test_session.py
@@ -302,7 +302,7 @@ class TestMCPServerSessionToolsCall:
         msg = JsonRpcRequest(
             id=2,
             method="tools/call",
-            params={"name": "hamster_search", "arguments": {"query": "light"}},
+            params={"name": "search", "arguments": {"query": "light"}},
         )
         result = session.handle(msg, registry, user_id=None)
         assert isinstance(result, SessionToolCall)
@@ -321,9 +321,7 @@ class TestMCPServerSessionToolsCall:
         from hamster.mcp._core.jsonrpc import JsonRpcRequest
 
         session, registry = self._make_active_session()
-        msg = JsonRpcRequest(
-            id=2, method="tools/call", params={"name": "hamster_search"}
-        )
+        msg = JsonRpcRequest(id=2, method="tools/call", params={"name": "search"})
         result = session.handle(msg, registry, user_id=None)
         # Should still work - arguments defaults to {}
         assert isinstance(result, SessionToolCall)
@@ -711,7 +709,7 @@ class TestSessionManagerToolCallParams:
     def test_arguments_wrong_type(self) -> None:
         manager, sess = self._make_active_manager()
         body = make_jsonrpc_request(
-            "tools/call", {"name": "hamster_search", "arguments": "string"}
+            "tools/call", {"name": "search", "arguments": "string"}
         )
         result = manager.receive_request(
             make_request(body=body, session_id=sess), now=0.0
@@ -902,7 +900,7 @@ class TestSessionManagerConcurrency:
         body1 = make_jsonrpc_request(
             "tools/call",
             {
-                "name": "hamster_call",
+                "name": "call",
                 "arguments": {"path": "services/light.turn_on"},
             },
             request_id=1,
@@ -910,7 +908,7 @@ class TestSessionManagerConcurrency:
         body2 = make_jsonrpc_request(
             "tools/call",
             {
-                "name": "hamster_call",
+                "name": "call",
                 "arguments": {"path": "services/light.turn_on"},
             },
             request_id=2,
@@ -1016,7 +1014,7 @@ class TestHappyPath:
         # 4. Call tool
         call_body = make_jsonrpc_request(
             "tools/call",
-            {"name": "hamster_search", "arguments": {"query": "light"}},
+            {"name": "search", "arguments": {"query": "light"}},
         )
         call_result = manager.receive_request(
             make_request(body=call_body, session_id="test-session-id"), now=0.0

--- a/src/hamster/mcp/_tests/test_tools.py
+++ b/src/hamster/mcp/_tests/test_tools.py
@@ -48,10 +48,10 @@ class TestToolDefinitions:
     def test_expected_tool_names(self) -> None:
         names = {t.name for t in TOOLS}
         assert names == {
-            "hamster_search",
-            "hamster_explain",
-            "hamster_call",
-            "hamster_schema",
+            "search",
+            "explain",
+            "call",
+            "schema",
         }
 
 
@@ -77,14 +77,14 @@ class TestCallTool:
 
     def test_search_returns_done(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_search", {"query": "light"}, registry, user_id=None)
+        result = call_tool("search", {"query": "light"}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.content[0].text  # type: ignore[union-attr]
 
     def test_search_with_path_filter(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_search",
+            "search",
             {"query": "turn", "path_filter": "services"},
             registry,
             user_id=None,
@@ -96,7 +96,7 @@ class TestCallTool:
     def test_search_with_domain_filter(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_search",
+            "search",
             {"query": "turn", "path_filter": "services/light"},
             registry,
             user_id=None,
@@ -110,7 +110,7 @@ class TestCallTool:
     def test_explain_returns_done(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_explain",
+            "explain",
             {"path": "services/light.turn_on"},
             registry,
             user_id=None,
@@ -121,7 +121,7 @@ class TestCallTool:
     def test_explain_unknown_command_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_explain",
+            "explain",
             {"path": "services/light.nonexistent"},
             registry,
             user_id=None,
@@ -132,7 +132,7 @@ class TestCallTool:
     def test_explain_unknown_group_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_explain",
+            "explain",
             {"path": "unknown/foo"},
             registry,
             user_id=None,
@@ -143,7 +143,7 @@ class TestCallTool:
     def test_explain_invalid_path_format_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_explain",
+            "explain",
             {"path": "nogroup"},
             registry,
             user_id=None,
@@ -156,7 +156,7 @@ class TestCallTool:
     def test_explain_empty_path_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_explain",
+            "explain",
             {"path": ""},
             registry,
             user_id=None,
@@ -167,7 +167,7 @@ class TestCallTool:
     def test_call_valid_service_returns_service_call(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_call",
+            "call",
             {
                 "path": "services/light.turn_on",
                 "arguments": {
@@ -189,7 +189,7 @@ class TestCallTool:
     def test_call_unknown_service_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_call",
+            "call",
             {"path": "services/light.nonexistent", "arguments": {}},
             registry,
             user_id=None,
@@ -200,7 +200,7 @@ class TestCallTool:
     def test_call_unknown_group_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_call",
+            "call",
             {"path": "unknown/foo", "arguments": {}},
             registry,
             user_id=None,
@@ -211,7 +211,7 @@ class TestCallTool:
     def test_call_invalid_path_format_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_call",
+            "call",
             {"path": "nogroup"},
             registry,
             user_id=None,
@@ -222,7 +222,7 @@ class TestCallTool:
     def test_call_missing_arguments_uses_empty(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_call",
+            "call",
             {"path": "services/light.turn_on"},
             registry,
             user_id="test-user",
@@ -234,7 +234,7 @@ class TestCallTool:
     def test_call_arguments_wrong_type_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_call",
+            "call",
             {"path": "services/light.turn_on", "arguments": "invalid"},
             registry,
             user_id=None,
@@ -244,9 +244,7 @@ class TestCallTool:
 
     def test_search_empty_registry(self) -> None:
         registry = GroupRegistry()
-        result = call_tool(
-            "hamster_search", {"query": "anything"}, registry, user_id=None
-        )
+        result = call_tool("search", {"query": "anything"}, registry, user_id=None)
         assert isinstance(result, Done)
         text = result.result.content[0].text  # type: ignore[union-attr]
         assert "No commands found" in text
@@ -254,7 +252,7 @@ class TestCallTool:
     def test_schema_returns_done(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_schema",
+            "schema",
             {"path": "services/selector/boolean"},
             registry,
             user_id=None,
@@ -282,7 +280,7 @@ class TestCallTool:
         )
         registry.register(group)
         result = call_tool(
-            "hamster_schema",
+            "schema",
             {"path": "services/light.turn_on"},
             registry,
             user_id=None,
@@ -294,7 +292,7 @@ class TestCallTool:
     def test_schema_unknown_path_error(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_schema",
+            "schema",
             {"path": "services/unknown.service"},
             registry,
             user_id=None,
@@ -320,20 +318,20 @@ class TestCallToolArgumentValidation:
 
     def test_search_missing_query(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_search", {}, registry, user_id=None)
+        result = call_tool("search", {}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 
     def test_search_query_wrong_type(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_search", {"query": 123}, registry, user_id=None)
+        result = call_tool("search", {"query": 123}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 
     def test_search_path_filter_wrong_type(self) -> None:
         registry = self._make_registry()
         result = call_tool(
-            "hamster_search",
+            "search",
             {"query": "test", "path_filter": 123},
             registry,
             user_id=None,
@@ -343,37 +341,37 @@ class TestCallToolArgumentValidation:
 
     def test_explain_missing_path(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_explain", {}, registry, user_id=None)
+        result = call_tool("explain", {}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 
     def test_explain_path_wrong_type(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_explain", {"path": 123}, registry, user_id=None)
+        result = call_tool("explain", {"path": 123}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 
     def test_call_missing_path(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_call", {}, registry, user_id=None)
+        result = call_tool("call", {}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 
     def test_call_path_wrong_type(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_call", {"path": 123}, registry, user_id=None)
+        result = call_tool("call", {"path": 123}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 
     def test_schema_missing_path(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_schema", {}, registry, user_id=None)
+        result = call_tool("schema", {}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 
     def test_schema_path_wrong_type(self) -> None:
         registry = self._make_registry()
-        result = call_tool("hamster_schema", {"path": 123}, registry, user_id=None)
+        result = call_tool("schema", {"path": 123}, registry, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
 


### PR DESCRIPTION
## Summary

- Renamed MCP tools from `hamster_search`, `hamster_explain`, `hamster_call`, `hamster_schema` to `search`, `explain`, `call`, `schema`
- MCP clients prefix tool names with the server name ("hamster"), so tools were appearing doubled as `hamster_hamster_search`, etc.
- With this change, clients will correctly display tools as `hamster_search`, `hamster_explain`, `hamster_call`, `hamster_schema`