### PR TITLE
Fix orjson.Fragment serialization in WebSocket command results

### DIFF
--- a/src/hamster/component/_tests/test_hass_effects.py
+++ b/src/hamster/component/_tests/test_hass_effects.py
@@ -94,6 +94,62 @@ class TestInternalConnectionSendResult:
         assert conn.error is None
         assert conn._result_event.is_set()
 
+    def test_send_result_unwraps_orjson_fragment(self) -> None:
+        """send_result unwraps orjson.Fragment objects in the result.
+
+        Some HA WebSocket handlers return data containing orjson.Fragment
+        objects for performance (pre-serialized JSON). The InternalConnection
+        must unwrap these so the result contains only plain Python types.
+        """
+        import orjson
+
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        # Simulate a result containing orjson.Fragment objects
+        result_with_fragments = {
+            "normal_key": "normal_value",
+            "fragment_key": orjson.Fragment(b'{"nested": "data"}'),
+            "list_with_fragment": [1, orjson.Fragment(b'"string_value"'), 3],
+        }
+
+        conn.send_result(1, result_with_fragments)
+
+        # The result should be unwrapped to plain Python types
+        assert conn.result == {
+            "normal_key": "normal_value",
+            "fragment_key": {"nested": "data"},
+            "list_with_fragment": [1, "string_value", 3],
+        }
+        assert conn.error is None
+        assert conn._result_event.is_set()
+
+    def test_send_result_unwraps_deeply_nested_fragments(self) -> None:
+        """send_result unwraps deeply nested orjson.Fragment objects."""
+        import orjson
+
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        # Simulate deeply nested fragments
+        result_with_fragments = {
+            "level1": {
+                "level2": {
+                    "fragment": orjson.Fragment(b'{"deep": "value"}'),
+                }
+            }
+        }
+
+        conn.send_result(1, result_with_fragments)
+
+        assert conn.result == {
+            "level1": {
+                "level2": {
+                    "fragment": {"deep": "value"},
+                }
+            }
+        }
+
 
 class TestInternalConnectionSendError:
     """Tests for InternalConnection.send_error()."""

--- a/src/hamster/component/http.py
+++ b/src/hamster/component/http.py
@@ -80,8 +80,20 @@ class InternalConnection:
 
         Args:
             msg_id: Message ID (unused for internal invocation)
-            result: Command result
+            result: Command result (may contain orjson.Fragment objects)
+
+        Note:
+            Some HA handlers return data containing orjson.Fragment objects
+            for performance (pre-serialized JSON). We unwrap these by doing
+            a round-trip through orjson serialization.
         """
+        import orjson
+
+        # Unwrap any orjson.Fragment objects by serializing and deserializing.
+        # This ensures the result contains only plain Python types that can be
+        # serialized by any JSON library (e.g., the stdlib json module).
+        if result is not None:
+            result = orjson.loads(orjson.dumps(result))
         self.result = result
         self._result_event.set()
 


### PR DESCRIPTION
## Summary

- Fix `orjson.Fragment` objects being serialized as `"<orjson.Fragment object at 0x...>"` instead of their actual JSON content
- Unwrap Fragment objects via orjson round-trip serialization in `InternalConnection.send_result()`
- Add tests for fragment unwrapping (basic and deeply nested cases)

## Problem

Some Home Assistant WebSocket handlers return data containing `orjson.Fragment` objects for performance (pre-serialized JSON). When these results were passed to `json.dumps()` in `_format_hass_response`, they were converted to their string representation instead of the actual JSON data.

## Solution

In `InternalConnection.send_result()`, unwrap any `orjson.Fragment` objects by doing a round-trip through orjson serialization:

```python
if result is not None:
    result = orjson.loads(orjson.dumps(result))
```

This ensures the result contains only plain Python types that can be serialized by any JSON library.