### PR TITLE
Add mergify-pre-commit validation hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
     hooks:
       - id: shellcheck
 
+  - repo: https://github.com/Mergifyio/mergify-pre-commit
+    rev: 1.1.0
+    hooks:
+      - id: validate-mergify-config
+      - id: validate-mergify-config-location
+
   - repo: local
     hooks:
       - id: ruff-format


### PR DESCRIPTION
## Summary

- Adds the `Mergifyio/mergify-pre-commit` repo (rev `1.1.0`) to `.pre-commit-config.yaml`
- Includes both `validate-mergify-config` (schema validation) and `validate-mergify-config-location` (ensures a single config file) hooks
- Both hooks pass against the existing `.mergify.yml`

Closes #53