### PR TITLE
Change alls-green gate condition from always() to !cancelled()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
   checks:
     name: All checks
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [pre-commit, python, validate]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Replace `if: always()` with `if: ${{ !cancelled() }}` on the `checks` gate job in `ci.yml`
- Prevents the gate job from running (and posting a status) when the workflow is cancelled (e.g., by `cancel-in-progress` or manual cancellation)
- Aligns with the pattern already used in onshape-mcp and stoat

Closes #52