### PR TITLE
Rename CI status check context from 'All checks' to 'all'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/validate.yml
 
   checks:
-    name: All checks
+    name: all
     if: ${{ !cancelled() }}
     needs: [pre-commit, python, validate]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Renames the CI aggregation job display name from `All checks` to `all` to align with the convention used across sibling projects (mujou, onshape-mcp, stoat)

## Post-merge action required

After merging, update the `default` branch ruleset's required status check context from `All checks` to `all`:

```bash
gh api repos/altendky/hamster/rulesets/14082824 \
  --method PUT \
  --input - <<< '{"name":"default","target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},"rules":[{"type":"deletion"},{"type":"non_fast_forward"},{"type":"required_signatures"},{"type":"pull_request","parameters":{"required_approving_review_count":1,"dismiss_stale_reviews_on_push":true,"required_reviewers":[],"require_code_owner_review":false,"require_last_push_approval":false,"required_review_thread_resolution":false,"allowed_merge_methods":["merge"]}},{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"do_not_enforce_on_create":false,"required_status_checks":[{"context":"all","integration_id":15368}]}}],"bypass_actors":[]}'
```

Closes #44