### PR TITLE
Split docs enrichment descriptions by ### subsections

### DIFF
--- a/src/hamster/mcp/_core/docs_enrichment.py
+++ b/src/hamster/mcp/_core/docs_enrichment.py
@@ -33,6 +33,7 @@ _EXCLUDED_TYPES: frozenset[str] = frozenset(
 _CODE_BLOCK_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n```", re.DOTALL)
 _COMMENT_RE = re.compile(r"//[^\n]*")
 _H2_RE = re.compile(r"^## (.+)$", re.MULTILINE)
+_H3_RE = re.compile(r"^### (.+)$", re.MULTILINE)
 
 
 def parse_websocket_docs(markdown: str) -> dict[str, str]:
@@ -53,14 +54,31 @@ def parse_websocket_docs(markdown: str) -> dict[str, str]:
 
     sections = _split_h2_sections(markdown)
     for _heading, body in sections:
-        command_types = _extract_command_types(body)
-        description = body.strip()
-        if not description:
-            continue
+        preamble, subsections = _split_h3_subsections(body)
 
-        for cmd_type in command_types:
-            if cmd_type not in _EXCLUDED_TYPES and cmd_type not in result:
-                result[cmd_type] = description
+        if not subsections:
+            # No ### subsections — whole body is the description.
+            description = body.strip()
+            if not description:
+                continue
+            for cmd_type in _extract_command_types(body):
+                if cmd_type not in _EXCLUDED_TYPES and cmd_type not in result:
+                    result[cmd_type] = description
+        else:
+            # Assign preamble commands the preamble text.
+            if preamble:
+                for cmd_type in _extract_command_types(preamble):
+                    if cmd_type not in _EXCLUDED_TYPES and cmd_type not in result:
+                        result[cmd_type] = preamble
+
+            # Assign subsection commands their subsection text.
+            for _sub_heading, sub_body in subsections:
+                sub_desc = sub_body.strip()
+                if not sub_desc:
+                    continue
+                for cmd_type in _extract_command_types(sub_body):
+                    if cmd_type not in _EXCLUDED_TYPES and cmd_type not in result:
+                        result[cmd_type] = sub_desc
 
     return result
 
@@ -119,6 +137,37 @@ def _split_h2_sections(markdown: str) -> list[tuple[str, str]]:
         sections.append((heading, body))
 
     return sections
+
+
+def _split_h3_subsections(body: str) -> tuple[str, list[tuple[str, str]]]:
+    """Split an H2 section body into preamble and ``### `` subsections.
+
+    Args:
+        body: The body text of a ``## `` section (as returned by
+            :func:`_split_h2_sections`).
+
+    Returns:
+        A tuple of ``(preamble, subsections)`` where *preamble* is the text
+        before the first ``### `` heading (may be empty) and *subsections*
+        is a list of ``(heading, body)`` pairs for each ``### `` heading.
+        If there are no ``### `` headings, *subsections* is empty and
+        *preamble* contains the full body text.
+    """
+    matches = list(_H3_RE.finditer(body))
+    if not matches:
+        return body, []
+
+    preamble = body[: matches[0].start()].strip()
+    subsections: list[tuple[str, str]] = []
+
+    for i, match in enumerate(matches):
+        heading = match.group(1).strip()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sub_body = body[start:end].strip()
+        subsections.append((heading, sub_body))
+
+    return preamble, subsections
 
 
 def _extract_command_types(text: str) -> list[str]:

--- a/src/hamster/mcp/_tests/test_docs_enrichment.py
+++ b/src/hamster/mcp/_tests/test_docs_enrichment.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from hamster.mcp._core.docs_enrichment import (
     _extract_command_types,
     _split_h2_sections,
+    _split_h3_subsections,
     _type_from_json,
     _type_from_regex,
     enrich_commands,
@@ -60,6 +61,56 @@ class TestSplitH2Sections:
         result = _split_h2_sections(md)
         assert len(result) == 1
         assert result[0][0] == "First"
+
+
+# ---------------------------------------------------------------------------
+# _split_h3_subsections
+# ---------------------------------------------------------------------------
+
+
+class TestSplitH3Subsections:
+    """Tests for _split_h3_subsections."""
+
+    def test_empty(self) -> None:
+        preamble, subs = _split_h3_subsections("")
+        assert preamble == ""
+        assert subs == []
+
+    def test_no_subsections(self) -> None:
+        body = "Just some text.\n\nMore text."
+        preamble, subs = _split_h3_subsections(body)
+        assert preamble == body
+        assert subs == []
+
+    def test_preamble_and_subsections(self) -> None:
+        body = (
+            "Intro text.\n\n"
+            "### Sub One\n\nSub one body.\n\n"
+            "### Sub Two\n\nSub two body.\n"
+        )
+        preamble, subs = _split_h3_subsections(body)
+        assert preamble == "Intro text."
+        assert len(subs) == 2
+        assert subs[0][0] == "Sub One"
+        assert "Sub one body" in subs[0][1]
+        assert subs[1][0] == "Sub Two"
+        assert "Sub two body" in subs[1][1]
+
+    def test_no_preamble(self) -> None:
+        body = "### First\n\nFirst body.\n\n### Second\n\nSecond body.\n"
+        preamble, subs = _split_h3_subsections(body)
+        assert preamble == ""
+        assert len(subs) == 2
+        assert subs[0][0] == "First"
+        assert "First body" in subs[0][1]
+
+    def test_single_subsection(self) -> None:
+        body = "Preamble.\n\n### Only sub\n\nSub body.\n"
+        preamble, subs = _split_h3_subsections(body)
+        assert preamble == "Preamble."
+        assert len(subs) == 1
+        assert subs[0][0] == "Only sub"
+        assert "Sub body" in subs[0][1]
 
 
 # ---------------------------------------------------------------------------
@@ -229,10 +280,18 @@ class TestParseWebsocketDocs:
             '  "type": "homeassistant/expose_entity"\n}\n```\n'
         )
         result = parse_websocket_docs(md)
-        # Both commands extracted from the single ## section, sharing
-        # the same full-section description
+        # Each command gets its subsection-specific description
         assert "homeassistant/expose_entity/list" in result
         assert "homeassistant/expose_entity" in result
+
+        list_desc = result["homeassistant/expose_entity/list"]
+        expose_desc = result["homeassistant/expose_entity"]
+
+        assert "Returns the exposure status" in list_desc
+        assert "Expose or unexpose" not in list_desc
+
+        assert "Expose or unexpose" in expose_desc
+        assert "Returns the exposure status" not in expose_desc
 
     def test_first_type_wins_for_duplicate(self) -> None:
         md = (
@@ -255,6 +314,53 @@ class TestParseWebsocketDocs:
 
     def test_empty_input(self) -> None:
         assert parse_websocket_docs("") == {}
+
+    def test_preamble_command_in_multi_subsection_section(self) -> None:
+        md = (
+            "## Subscribe to trigger\n\n"
+            "You can subscribe to triggers.\n\n"
+            '```json\n{\n  "id": 2,\n  "type": "subscribe_trigger"\n}\n```\n\n'
+            "### Unsubscribing from events\n\n"
+            "To unsubscribe:\n\n"
+            '```json\n{\n  "id": 3,\n  "type": "unsubscribe_events"\n}\n```\n'
+        )
+        result = parse_websocket_docs(md)
+        assert "subscribe_trigger" in result
+        assert "unsubscribe_events" in result
+
+        sub_desc = result["subscribe_trigger"]
+        unsub_desc = result["unsubscribe_events"]
+
+        assert "subscribe to triggers" in sub_desc
+        assert "unsubscribe" not in sub_desc.lower()
+
+        assert "To unsubscribe" in unsub_desc
+        assert "subscribe to triggers" not in unsub_desc
+
+    def test_section_without_subsections_unchanged(self) -> None:
+        md = (
+            "## Fetching states\n\n"
+            "This will get a dump of all states.\n\n"
+            '```json\n{\n  "id": 19,\n  "type": "get_states"\n}\n```\n'
+        )
+        result = parse_websocket_docs(md)
+        assert "get_states" in result
+        assert "dump of all states" in result["get_states"]
+
+    def test_subsection_with_no_commands_skipped(self) -> None:
+        md = (
+            "## Topic\n\n"
+            "Intro.\n\n"
+            "### Background\n\n"
+            "Just prose, no code blocks.\n\n"
+            "### The command\n\n"
+            "Do the thing.\n\n"
+            '```json\n{\n  "id": 1,\n  "type": "do_thing"\n}\n```\n'
+        )
+        result = parse_websocket_docs(md)
+        assert "do_thing" in result
+        assert "Do the thing" in result["do_thing"]
+        assert "Just prose" not in result["do_thing"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When a `## ` section contains `### ` subsections with separate commands, each command now gets its subsection-specific description instead of the full section body
- Commands in the preamble (before the first `### `) get the preamble text
- Sections without `### ` subsections behave exactly as before

## Details

Added `_split_h3_subsections()` helper that splits an H2 section body into `(preamble, [(heading, body), ...])`. Updated `parse_websocket_docs()` to use subsection-level descriptions when subsections are present.

**Example impact (real HA docs):**
- `homeassistant/expose_entity/list` now gets ~32 lines (its `### List exposed entities` subsection) instead of ~67 lines (the full `## Manage exposed entities` section)
- `unsubscribe_events` now gets ~20 lines (its `### Unsubscribing from events` subsection) instead of ~105 lines (the full `## Subscribe to trigger` section)

## Tests

- 5 new tests for `_split_h3_subsections()` (empty, no subsections, preamble + subsections, no preamble, single subsection)
- 3 new tests for `parse_websocket_docs()` (preamble command in multi-subsection section, section without subsections unchanged, subsection with no commands skipped)
- Updated `test_multiple_commands_in_one_section` to assert subsection-specific descriptions

Closes #62