### PR TITLE
Add lychee markdown link checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ htmlcov/
 
 # ruff
 .ruff_cache/
+
+# lychee
+.lycheecache

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,75 @@
+# lychee link checker configuration
+# https://github.com/lycheeverse/lychee
+
+#############################  Display  #############################
+
+# Verbose program output
+verbose = "warn"
+
+# Don't show interactive progress bar while checking links
+no_progress = false
+
+#############################  Cache  ###############################
+
+# Enable link caching to speed up repeated runs
+cache = true
+
+# Discard cached requests older than this duration
+max_cache_age = "1d"
+
+#############################  Runtime  #############################
+
+# Maximum number of allowed redirects
+max_redirects = 10
+
+# Maximum number of retries before declaring a link dead
+max_retries = 3
+
+# Maximum concurrent link checks
+max_concurrency = 16
+
+#############################  Requests  ############################
+
+# Website timeout from connect to response finished (seconds)
+timeout = 30
+
+# Minimum wait time in seconds between retries
+retry_wait_time = 2
+
+# Proceed for server connections considered insecure (invalid TLS)
+insecure = false
+
+# Request method (HEAD is faster, GET is more reliable)
+method = "get"
+
+#############################  Exclusions  ##########################
+
+# Exclude URLs from checking (regex patterns)
+exclude = [
+    # Placeholder/example URLs
+    "^https?://localhost",
+    "^https?://127\\.0\\.0\\.1",
+    "^https?://\\[::1\\]",
+    "^https?://example\\.(com|org|net)",
+    "^https://\\.\\.\\.",  # Literal "https://..." placeholder
+
+    # URLs containing shell/template variables (not real URLs)
+    "\\$\\{",    # Shell variables like ${VERSION}
+    "\\$%7B",    # URL-encoded shell variables
+
+    # Example/placeholder hostnames used in documentation
+    "^https?://evil\\.com",                    # CORS rejection example
+    "^https?://[^/]*homeassistant\\.local",    # Local HA hostname
+]
+
+# Check these file extensions
+extensions = ["md"]
+
+# Enable fragment/anchor checking
+include_fragments = true
+
+# Exclude mail addresses from checking (avoid false positives)
+include_mail = false
+
+# Exclude all private IPs
+exclude_all_private = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
     hooks:
       - id: markdownlint-cli2
 
+  - repo: https://github.com/lycheeverse/lychee
+    rev: lychee-v0.23.0
+    hooks:
+      - id: lychee
+        args: ["--no-progress", "--config=.lychee.toml"]
+        types: [markdown]
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11
     hooks:


### PR DESCRIPTION
## Summary

- Add lychee as a pre-commit hook to check for broken links in markdown files, matching the setup in stoat and onshape-mcp
- Add `.lychee.toml` with `include_fragments = true`, private IP exclusion, and exclusions for placeholder/example URLs used in documentation
- Add `.lycheecache` to `.gitignore`

Closes #65