### PR TITLE
Align markdownlint-cli2 configuration

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -10,7 +10,15 @@ gitignore: true
 config:
   # Disable line length checking --- we use semantic newlines
   MD013: false
+  # Allow duplicate headings under different parents
+  MD024:
+    siblings_only: true
   # Allow <img> for sized icon in README heading
   MD033:
     allowed_elements:
       - img
+  # Allow bold text used as labeled paragraphs
+  MD036: false
+  # Enforce compact table style
+  MD060:
+    style: compact

--- a/src/hamster_mcp/mcp/_core/resources/insights/entity-ids.md
+++ b/src/hamster_mcp/mcp/_core/resources/insights/entity-ids.md
@@ -106,25 +106,25 @@ Diagnostic and config entities are typically not targets for service calls.
 
 ## Common Domains
 
-| Domain            | Description                 | Typical services                    |
-|------------------ |---------------------------- |------------------------------------ |
-| `light`           | Lights                      | `turn_on`, `turn_off`, `toggle`     |
-| `switch`          | Switches                    | `turn_on`, `turn_off`, `toggle`     |
-| `sensor`          | Sensors (read-only)         | (none --- sensors have no services) |
-| `binary_sensor`   | On/off sensors (read-only)  | (none)                              |
-| `climate`         | Thermostats, HVAC           | `set_temperature`, `set_hvac_mode`  |
-| `cover`           | Blinds, garage doors        | `open_cover`, `close_cover`         |
-| `media_player`    | Media devices               | `play_media`, `volume_set`          |
-| `fan`             | Fans                        | `turn_on`, `set_percentage`         |
-| `lock`            | Locks                       | `lock`, `unlock`                    |
-| `automation`      | Automations                 | `trigger`, `turn_on`, `turn_off`    |
-| `script`          | Scripts                     | `turn_on` (or call by entity ID)    |
-| `scene`           | Scenes                      | `turn_on`                           |
-| `input_boolean`   | Virtual toggles             | `turn_on`, `turn_off`, `toggle`     |
-| `input_number`    | Virtual number inputs       | `set_value`                         |
-| `input_select`    | Virtual dropdowns           | `select_option`                     |
-| `input_text`      | Virtual text inputs         | `set_value`                         |
-| `input_datetime`  | Virtual date/time inputs    | `set_datetime`                      |
+| Domain | Description | Typical services |
+| --- | --- | --- |
+| `light` | Lights | `turn_on`, `turn_off`, `toggle` |
+| `switch` | Switches | `turn_on`, `turn_off`, `toggle` |
+| `sensor` | Sensors (read-only) | (none --- sensors have no services) |
+| `binary_sensor` | On/off sensors (read-only) | (none) |
+| `climate` | Thermostats, HVAC | `set_temperature`, `set_hvac_mode` |
+| `cover` | Blinds, garage doors | `open_cover`, `close_cover` |
+| `media_player` | Media devices | `play_media`, `volume_set` |
+| `fan` | Fans | `turn_on`, `set_percentage` |
+| `lock` | Locks | `lock`, `unlock` |
+| `automation` | Automations | `trigger`, `turn_on`, `turn_off` |
+| `script` | Scripts | `turn_on` (or call by entity ID) |
+| `scene` | Scenes | `turn_on` |
+| `input_boolean` | Virtual toggles | `turn_on`, `turn_off`, `toggle` |
+| `input_number` | Virtual number inputs | `set_value` |
+| `input_select` | Virtual dropdowns | `select_option` |
+| `input_text` | Virtual text inputs | `set_value` |
+| `input_datetime` | Virtual date/time inputs | `set_datetime` |
 
 ## Resolving Friendly Names
 

--- a/src/hamster_mcp/mcp/_core/resources/insights/service-targeting.md
+++ b/src/hamster_mcp/mcp/_core/resources/insights/service-targeting.md
@@ -29,13 +29,13 @@ invocation.  All fields are optional; combine them to narrow or broaden scope.
 
 ### Fields
 
-| Field       | Type                 | Description                                     |
-| ----------- | -------------------- | ----------------------------------------------- |
-| `entity_id` | `string \| [string]` | One or more entity IDs                          |
-| `device_id` | `string \| [string]` | One or more device IDs (opaque hex strings)     |
-| `area_id`   | `string \| [string]` | One or more area slugs (e.g. `"living_room"`)   |
-| `floor_id`  | `string \| [string]` | One or more floor slugs (e.g. `"ground_floor"`) |
-| `label_id`  | `string \| [string]` | One or more label slugs                         |
+| Field | Type | Description |
+| --- | --- | --- |
+| `entity_id` | `string \| [string]` | One or more entity IDs |
+| `device_id` | `string \| [string]` | One or more device IDs (opaque hex strings) |
+| `area_id` | `string \| [string]` | One or more area slugs (e.g. `"living_room"`) |
+| `floor_id` | `string \| [string]` | One or more floor slugs (e.g. `"ground_floor"`) |
+| `label_id` | `string \| [string]` | One or more label slugs |
 
 Each field accepts either a single string or an array of strings.
 

--- a/src/hamster_mcp/mcp/_core/resources/insights/services-and-hass.md
+++ b/src/hamster_mcp/mcp/_core/resources/insights/services-and-hass.md
@@ -99,11 +99,11 @@ in a single bulk response rather than individual searchable entries.
 
 ## Metadata Comparison
 
-| Capability                  | `services/` group         | `hass/call_service`       |
-| --------------------------- | ------------------------- | ------------------------- |
-| Per-service `explain`       | Yes                       | No (single generic entry) |
-| Per-service `schema`        | Yes (with selectors)      | No                        |
-| Searchable by keyword       | Yes                       | No                        |
-| Target specifications       | Yes (domain, integration) | No                        |
-| Field descriptions          | Yes                       | Via `hass/get_services`   |
-| Can call any service        | Yes (indexed services)    | Yes                       |
+| Capability | `services/` group | `hass/call_service` |
+| --- | --- | --- |
+| Per-service `explain` | Yes | No (single generic entry) |
+| Per-service `schema` | Yes (with selectors) | No |
+| Searchable by keyword | Yes | No |
+| Target specifications | Yes (domain, integration) | No |
+| Field descriptions | Yes | Via `hass/get_services` |
+| Can call any service | Yes (indexed services) | Yes |


### PR DESCRIPTION
## Summary

- Add three markdownlint rules to `.markdownlint-cli2.yaml` to match the cross-project standard: `MD024` (siblings_only), `MD036` (disabled), `MD060` (compact table style)
- Fix existing tables in three resource insight files to use compact style (single-space padding instead of column-aligned padding)

Closes #64