### PR TITLE
Fix ARG_MAX overflow in post-release blob creation

### DIFF
--- a/.github/workflows/reflow-post-release.yml
+++ b/.github/workflows/reflow-post-release.yml
@@ -98,20 +98,18 @@ jobs:
           base_tree=$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$base_sha" --jq '.tree.sha')
 
           # Create blobs for modified files
-          manifest_blob=$(gh api "repos/$GITHUB_REPOSITORY/git/blobs" \
-            -f content="$(base64 -w0 < custom_components/hamster_mcp/manifest.json)" \
-            -f encoding=base64 \
-            --jq '.sha')
+          # Uses temp file + jq --rawfile to avoid ARG_MAX limits on large files
+          create_blob() {
+            local file="$1"
+            base64 -w0 < "$file" > "$RUNNER_TEMP/blob.b64"
+            jq -n --rawfile content "$RUNNER_TEMP/blob.b64" \
+              '{content: $content, encoding: "base64"}' \
+              | gh api "repos/$GITHUB_REPOSITORY/git/blobs" --input - --jq '.sha'
+          }
 
-          pyproject_blob=$(gh api "repos/$GITHUB_REPOSITORY/git/blobs" \
-            -f content="$(base64 -w0 < pyproject.toml)" \
-            -f encoding=base64 \
-            --jq '.sha')
-
-          uvlock_blob=$(gh api "repos/$GITHUB_REPOSITORY/git/blobs" \
-            -f content="$(base64 -w0 < uv.lock)" \
-            -f encoding=base64 \
-            --jq '.sha')
+          manifest_blob=$(create_blob custom_components/hamster_mcp/manifest.json)
+          pyproject_blob=$(create_blob pyproject.toml)
+          uvlock_blob=$(create_blob uv.lock)
 
           # Create tree
           tree_sha=$(jq -n \


### PR DESCRIPTION
## Summary

- The `uv.lock` base64-encoded content exceeds the shell's `ARG_MAX` limit when passed as a `gh api -f` command-line argument, causing the post-release workflow to fail with exit code 126.
- Uses a temp file + `jq --rawfile` to pipe the blob payload via stdin instead, avoiding the argument length limit entirely.

## Context

The manually-dispatched post-release workflow ([run #1](https://github.com/altendky/hamster-mcp/actions/runs/24007592942/job/70013782139)) failed at blob creation:

```
/usr/bin/gh: Argument list too long
```

This is the first real execution of the workflow added in PR #92.

## After merging

Re-run the `Post-release PR` workflow dispatch to create the signed post-release PR.