### PR TITLE
Use GraphQL createCommitOnBranch for signed post-release commits

### DIFF
--- a/.github/workflows/reflow-post-release.yml
+++ b/.github/workflows/reflow-post-release.yml
@@ -99,7 +99,7 @@ jobs:
           base64 -w0 < uv.lock > "$RUNNER_TEMP/uvlock.b64"
 
           # Create commit via GraphQL (GitHub signs commits created through this mutation)
-          commit_sha=$(jq -n \
+          response=$(jq -n \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg branch "$branch" \
             --arg msg "Begin $next_dev development" \
@@ -126,10 +126,13 @@ jobs:
                   expectedHeadOid: $head
                 }
               }
-            }' | gh api graphql --input - --jq '.data.createCommitOnBranch.commit.oid')
+            }' | gh api graphql --input -)
+
+          commit_sha=$(echo "$response" | jq -r '.data.createCommitOnBranch.commit.oid // empty')
 
           if [[ -z "$commit_sha" ]]; then
             echo "::error::GraphQL createCommitOnBranch failed"
+            echo "$response" | jq '.errors // .data'
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- The REST API `POST /repos/{owner}/{repo}/git/commits` does **not** produce GitHub-signed commits when using App installation tokens — the previous two runs confirmed this ([run #1](https://github.com/altendky/hamster-mcp/actions/runs/24007592942) hit ARG_MAX, [run #2](https://github.com/altendky/hamster-mcp/actions/runs/24007861904) created an unsigned commit).
- Switch to the GraphQL `createCommitOnBranch` mutation, which triggers GitHub's commit signing infrastructure.
- This also simplifies the workflow: the mutation handles blobs, trees, and commits atomically, replacing the manual blob -> tree -> commit chain.
- File contents are base64-encoded to temp files and loaded via `jq --rawfile` to avoid ARG_MAX limits on large files like `uv.lock`.
- The bot identity lookup is removed since `createCommitOnBranch` uses the App's authenticated identity automatically.

## After merging

Re-run the `Post-release PR` workflow dispatch.