### PR TITLE
Fix blocking file I/O in async_setup_entry for resource loading

### DIFF
--- a/src/hamster_mcp/component/__init__.py
+++ b/src/hamster_mcp/component/__init__.py
@@ -330,7 +330,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Create components
     server_info = ServerInfo(name="hamster-mcp", version=_HAMSTER_VERSION)
-    resources = load_all_resources()
+    resources = await hass.async_add_executor_job(load_all_resources)
 
     manager = SessionManager(
         server_info=server_info,


### PR DESCRIPTION
## Summary

- Wraps `load_all_resources()` in `hass.async_add_executor_job()` to offload synchronous `importlib.resources` file reads to the thread pool executor, preventing the Home Assistant event loop from being blocked during config entry setup.

## Problem

`load_all_resources()` performs synchronous `read_text()` calls on 5 markdown resource files via `importlib.resources`. When called directly from `async_setup_entry()`, this blocks the event loop and triggers a `Detected blocking call to open` warning:

https://gist.github.com/HanaanY/2790fb6f20fa47904478a92ada1ee0e2

## Fix

One-line change at `src/hamster_mcp/component/__init__.py:333`:

```python
# Before
resources = load_all_resources()

# After
resources = await hass.async_add_executor_job(load_all_resources)
```

No changes needed in `_io/resources.py` or `_core/` — the function is already a plain synchronous function, which is the correct signature for `async_add_executor_job`.