### PR TITLE
Fix send_result crash on dicts with non-string keys

### DIFF
--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -150,6 +150,17 @@ class TestInternalConnectionSendResult:
             }
         }
 
+    def test_send_result_handles_non_string_keys(self) -> None:
+        """send_result handles dicts with non-string keys (e.g. script/config)."""
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        conn.send_result(1, {1: "value", "normal": "data"})
+
+        assert conn.result == {"1": "value", "normal": "data"}
+        assert conn.error is None
+        assert conn._result_event.is_set()
+
 
 class TestInternalConnectionSendError:
     """Tests for InternalConnection.send_error()."""

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -88,7 +88,7 @@ class InternalConnection:
         # This ensures the result contains only plain Python types that can be
         # serialized by any JSON library (e.g., the stdlib json module).
         if result is not None:
-            result = orjson.loads(orjson.dumps(result))
+            result = orjson.loads(orjson.dumps(result, option=orjson.OPT_NON_STR_KEYS))
         self.result = result
         self._result_event.set()
 


### PR DESCRIPTION
## Summary

- Pass `orjson.OPT_NON_STR_KEYS` to `orjson.dumps()` in `InternalConnection.send_result()` so non-string dict keys (e.g. integers returned by `script/config`) are stringified instead of raising `TypeError: Dict key must be str`
- Add test for non-string dict key handling in `TestInternalConnectionSendResult`

Closes #98