### PR TITLE
Align ci.yml concurrency pattern with onshape-mcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   pre-commit:


### PR DESCRIPTION
## Summary

- Replace the top-level CI concurrency grouping (`workflow-ref`) with the onshape-mcp pattern that groups PRs by PR number and gives main/tag pushes unique `run_id` groups
- PRs still get stale runs cancelled on new pushes; main and tag pushes can never cancel each other

Closes #108