### PR TITLE
Add explicit branch filter to pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `branches: ["**"]` to the `pull_request` trigger in `ci.yml`, making the all-branches behavior explicit rather than implicit
- No behavioral change — just improved self-documentation, matching the convention used in onshape-mcp

Closes #109