### PR TITLE
Fix Context serialization in hass/call_service

### DIFF
--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -161,6 +161,38 @@ class TestInternalConnectionSendResult:
         assert conn.error is None
         assert conn._result_event.is_set()
 
+    def test_send_result_serializes_context_via_as_dict(self) -> None:
+        """send_result serializes Context objects using as_dict().
+
+        Home Assistant's Context class is not directly JSON-serializable,
+        but has an as_dict() method. The serialization should use this.
+        """
+        from homeassistant.core import Context
+
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        context = Context(user_id="test_user")
+        result_with_context = {
+            "context": context,
+            "other_data": "value",
+        }
+
+        conn.send_result(1, result_with_context)
+
+        # Context should be serialized via as_dict()
+        assert conn.result is not None
+        assert isinstance(conn.result, dict)
+        result: dict[str, object] = conn.result
+        assert result["other_data"] == "value"
+        context_dict = result["context"]
+        assert isinstance(context_dict, dict)
+        assert context_dict["user_id"] == "test_user"
+        assert context_dict["parent_id"] is None
+        assert "id" in context_dict  # Context generates an ID
+        assert conn.error is None
+        assert conn._result_event.is_set()
+
 
 class TestInternalConnectionSendError:
     """Tests for InternalConnection.send_error()."""

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -39,6 +39,26 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _orjson_default(obj: object) -> object:
+    """Convert non-serializable objects for orjson.
+
+    Handles objects with as_dict() method (e.g., Context) by converting
+    them to dictionaries.
+
+    Args:
+        obj: Object that orjson doesn't know how to serialize
+
+    Returns:
+        JSON-serializable representation of the object
+
+    Raises:
+        TypeError: If object cannot be converted
+    """
+    if hasattr(obj, "as_dict"):
+        return obj.as_dict()
+    raise TypeError(f"Type is not JSON serializable: {type(obj).__name__}")
+
+
 @dataclass(frozen=False, slots=True)
 class InternalConnection:
     """Internal adapter for invoking WS handlers without a real WebSocket.
@@ -80,15 +100,23 @@ class InternalConnection:
         Note:
             Some HA handlers return data containing orjson.Fragment objects
             for performance (pre-serialized JSON). We unwrap these by doing
-            a round-trip through orjson serialization.
+            a round-trip through orjson serialization. Objects with as_dict()
+            methods (like Context) are converted to dicts.
         """
         import orjson
 
         # Unwrap any orjson.Fragment objects by serializing and deserializing.
         # This ensures the result contains only plain Python types that can be
         # serialized by any JSON library (e.g., the stdlib json module).
+        # The default handler converts objects with as_dict() (e.g., Context).
         if result is not None:
-            result = orjson.loads(orjson.dumps(result, option=orjson.OPT_NON_STR_KEYS))
+            result = orjson.loads(
+                orjson.dumps(
+                    result,
+                    option=orjson.OPT_NON_STR_KEYS,
+                    default=_orjson_default,
+                )
+            )
         self.result = result
         self._result_event.set()
 

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -54,8 +54,9 @@ def _orjson_default(obj: object) -> object:
     Raises:
         TypeError: If object cannot be converted
     """
-    if hasattr(obj, "as_dict"):
-        return obj.as_dict()
+    as_dict = getattr(obj, "as_dict", None)
+    if callable(as_dict):
+        return as_dict()
     raise TypeError(f"Type is not JSON serializable: {type(obj).__name__}")
 
 


### PR DESCRIPTION
## Summary

- Add `_orjson_default` helper function that converts objects with `as_dict()` methods to dictionaries during JSON serialization
- Update `InternalConnection.send_result()` to use this helper, fixing serialization of Home Assistant's `Context` objects

Closes #122