### PR TITLE
Fix services without response support failing via services/ path

### DIFF
--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -257,6 +257,8 @@ class HamsterEffectHandler:
         target: dict[str, object] | None,
         data: dict[str, object],
         user_id: str | None,
+        *,
+        supports_response: bool = True,
     ) -> ServiceCallResult:
         """Execute a Home Assistant service call.
 
@@ -266,6 +268,9 @@ class HamsterEffectHandler:
             target: Target entities/devices/areas, or None
             data: Service data parameters
             user_id: Authenticated user ID for authorization
+            supports_response: Whether service supports return_response.
+                Services without response support will fail if called with
+                return_response=True, so we only set it when supported.
 
         Returns:
             ServiceCallResult indicating success or failure
@@ -279,7 +284,7 @@ class HamsterEffectHandler:
                 target=target,
                 context=context,
                 blocking=True,
-                return_response=True,
+                return_response=supports_response,
             )
             # Cast result to dict[str, object] - HA returns JsonValueType but
             # our interface uses object for flexibility

--- a/src/hamster_mcp/mcp/_core/events.py
+++ b/src/hamster_mcp/mcp/_core/events.py
@@ -62,6 +62,7 @@ class ServiceCall:
     data: dict[str, object]
     user_id: str | None
     continuation: Continuation
+    supports_response: bool = True
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hamster_mcp/mcp/_core/groups.py
+++ b/src/hamster_mcp/mcp/_core/groups.py
@@ -513,6 +513,26 @@ class ServicesGroup:
             return False
         return service in domain_services
 
+    def _supports_response(self, domain: str, service: str) -> bool:
+        """Check if a service supports response data.
+
+        Args:
+            domain: Service domain (e.g. 'light')
+            service: Service name (e.g. 'turn_on')
+
+        Returns:
+            True if the service supports returning response data, False otherwise.
+            Services with a "response" key in their description support responses.
+        """
+        domain_services = self._descriptions.get(domain)
+        if not isinstance(domain_services, dict):
+            return False
+        service_data = domain_services.get(service)
+        if not isinstance(service_data, dict):
+            return False
+        # HA adds "response" key only when SupportsResponse is not NONE
+        return "response" in service_data
+
     def parse_call_args(
         self, path: str, arguments: dict[str, object], user_id: str | None
     ) -> ToolEffect:
@@ -554,4 +574,5 @@ class ServicesGroup:
             data=data,
             user_id=user_id,
             continuation=FormatServiceResponse(),
+            supports_response=self._supports_response(domain, service),
         )

--- a/src/hamster_mcp/mcp/_io/aiohttp.py
+++ b/src/hamster_mcp/mcp/_io/aiohttp.py
@@ -63,6 +63,8 @@ class EffectHandler(Protocol):
         target: dict[str, object] | None,
         data: dict[str, object],
         user_id: str | None,
+        *,
+        supports_response: bool = True,
     ) -> ServiceCallResult:
         """Execute a Home Assistant service call.
 
@@ -72,6 +74,7 @@ class EffectHandler(Protocol):
             target: Target entities/devices/areas, or None
             data: Service data parameters
             user_id: Authenticated user ID for authorization
+            supports_response: Whether service supports return_response
 
         Returns:
             ServiceCallResult indicating success or failure
@@ -241,6 +244,7 @@ class AiohttpMCPTransport:
                         current.target,
                         current.data,
                         current.user_id,
+                        supports_response=current.supports_response,
                     )
                 except Exception as err:
                     _LOGGER.exception(

--- a/src/hamster_mcp/mcp/_tests/test_aiohttp.py
+++ b/src/hamster_mcp/mcp/_tests/test_aiohttp.py
@@ -66,7 +66,7 @@ class MockEffectHandler:
     """Mock effect handler for testing."""
 
     calls: list[
-        tuple[str, str, dict[str, object] | None, dict[str, object], str | None]
+        tuple[str, str, dict[str, object] | None, dict[str, object], str | None, bool]
     ] = field(default_factory=list)
     hass_calls: list[tuple[str, dict[str, object], str | None]] = field(
         default_factory=list
@@ -90,9 +90,11 @@ class MockEffectHandler:
         target: dict[str, object] | None,
         data: dict[str, object],
         user_id: str | None,
+        *,
+        supports_response: bool = True,
     ) -> ServiceCallResult:
         """Execute mock service call."""
-        self.calls.append((domain, service, target, data, user_id))
+        self.calls.append((domain, service, target, data, user_id, supports_response))
         if self.should_raise is not None:
             raise self.should_raise
         return self.result

--- a/src/hamster_mcp/mcp/_tests/test_groups.py
+++ b/src/hamster_mcp/mcp/_tests/test_groups.py
@@ -451,3 +451,55 @@ class TestServicesGroupParseCallArgs:
         result = group.parse_call_args("light", {}, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
+
+    def test_supports_response_true_when_response_key_present(self) -> None:
+        """Service with 'response' key sets supports_response=True."""
+        # Service with response support (like weather.get_forecasts)
+        group = ServicesGroup.create(
+            {
+                "weather": {
+                    "get_forecasts": {
+                        "description": "Get weather forecast",
+                        "response": {"optional": False},  # SupportsResponse.ONLY
+                    }
+                }
+            }
+        )
+        result = group.parse_call_args("weather.get_forecasts", {}, user_id=None)
+        assert isinstance(result, ServiceCall)
+        assert result.supports_response is True
+
+    def test_supports_response_false_when_response_key_absent(self) -> None:
+        """Service without 'response' key sets supports_response=False."""
+        # Service without response support (like remote.send_command)
+        group = ServicesGroup.create(
+            {
+                "remote": {
+                    "send_command": {
+                        "description": "Send command to remote",
+                        "fields": {"command": {"required": True}},
+                        # No "response" key - service doesn't support responses
+                    }
+                }
+            }
+        )
+        result = group.parse_call_args("remote.send_command", {}, user_id=None)
+        assert isinstance(result, ServiceCall)
+        assert result.supports_response is False
+
+    def test_supports_response_optional_true(self) -> None:
+        """parse_call_args() handles SupportsResponse.OPTIONAL services."""
+        # Service with optional response support
+        group = ServicesGroup.create(
+            {
+                "calendar": {
+                    "get_events": {
+                        "description": "Get calendar events",
+                        "response": {"optional": True},  # SupportsResponse.OPTIONAL
+                    }
+                }
+            }
+        )
+        result = group.parse_call_args("calendar.get_events", {}, user_id=None)
+        assert isinstance(result, ServiceCall)
+        assert result.supports_response is True


### PR DESCRIPTION
## Summary

- Fix services that don't support responses failing with `ServiceValidationError` when called via the `services/` path
- The handler now checks whether a service supports response data before setting `return_response=True`

## Problem

When calling services via the `services/` path (e.g., `services/remote.send_command`), services that don't return a response failed with:

```
Error: Validation error: An action which does not return responses can't be called with return_response=True
```

This happened because `return_response=True` was unconditionally set in `execute_service_call()`.

## Solution

Home Assistant's `async_get_all_descriptions()` includes a `"response"` key only when a service supports responses (`SupportsResponse.OPTIONAL` or `SupportsResponse.ONLY`). This fix:

1. Adds a `supports_response` field to the `ServiceCall` effect
2. Extracts response support info from service descriptions in `ServicesGroup`
3. Passes the flag through the `EffectHandler` protocol
4. Conditionally sets `return_response` based on service capability

## Testing

- Added 3 new tests for response support detection
- All 612 tests pass
- Type checking passes

Closes #123