### PR TITLE
Implement registry enrichment for tool outputs

### DIFF
--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -557,7 +557,7 @@ class HamsterEffectHandler:
             labels_tuple = tuple(lid for lid in label_ids if isinstance(lid, str))
 
             devices[device_id] = DeviceInfo(
-                name=entry.get("name") or entry.get("name_by_user"),
+                name=entry.get("name_by_user") or entry.get("name"),
                 area_id=entry.get("area_id"),
                 labels=labels_tuple,
             )

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -23,6 +23,14 @@ from homeassistant.exceptions import (
 )
 import voluptuous as vol
 
+from hamster_mcp.mcp._core.registry_enrichment import (
+    AreaInfo,
+    DeviceInfo,
+    EntityInfo,
+    FloorInfo,
+    LabelInfo,
+    RegistryContext,
+)
 from hamster_mcp.mcp._core.types import (
     HassCommandResult,
     ServiceCallResult,
@@ -446,6 +454,182 @@ class HamsterEffectHandler:
             return SupervisorCallResult(
                 success=False, error=f"Supervisor error: {type(err).__name__}: {err}"
             )
+
+    async def fetch_registry_context(self) -> RegistryContext:
+        """Fetch registry data for enriching command outputs.
+
+        Retrieves entity, device, area, floor, and label registry data
+        from Home Assistant for use in enriching JSON outputs with
+        human-readable names.
+
+        Returns:
+            RegistryContext containing all registry data for lookups.
+            Returns empty context if registries are unavailable.
+        """
+        entities: dict[str, EntityInfo] = {}
+        devices: dict[str, DeviceInfo] = {}
+        areas: dict[str, AreaInfo] = {}
+        floors: dict[str, FloorInfo] = {}
+        labels: dict[str, LabelInfo] = {}
+
+        # Fetch all registries in parallel
+        results = await asyncio.gather(
+            self._fetch_entity_registry(),
+            self._fetch_device_registry(),
+            self._fetch_area_registry(),
+            self._fetch_floor_registry(),
+            self._fetch_label_registry(),
+            return_exceptions=True,
+        )
+
+        # Process results, ignoring any that failed
+        entity_result, device_result, area_result, floor_result, label_result = results
+
+        if isinstance(entity_result, dict):
+            entities = entity_result
+        if isinstance(device_result, dict):
+            devices = device_result
+        if isinstance(area_result, dict):
+            areas = area_result
+        if isinstance(floor_result, dict):
+            floors = floor_result
+        if isinstance(label_result, dict):
+            labels = label_result
+
+        return RegistryContext(
+            entities=entities,
+            devices=devices,
+            areas=areas,
+            floors=floors,
+            labels=labels,
+        )
+
+    async def _fetch_entity_registry(self) -> dict[str, EntityInfo]:
+        """Fetch entity registry data."""
+        result = await self.execute_hass_command(
+            "config/entity_registry/list", {}, None
+        )
+        if not result.success or not isinstance(result.data, list):
+            return {}
+
+        entities: dict[str, EntityInfo] = {}
+        for entry in result.data:
+            if not isinstance(entry, dict):
+                continue
+            entity_id = entry.get("entity_id")
+            if not isinstance(entity_id, str):
+                continue
+
+            # Extract label IDs
+            label_ids = entry.get("labels", [])
+            if not isinstance(label_ids, list):
+                label_ids = []
+            labels_tuple = tuple(lid for lid in label_ids if isinstance(lid, str))
+
+            entities[entity_id] = EntityInfo(
+                name=entry.get("name") or entry.get("original_name"),
+                device_id=entry.get("device_id"),
+                area_id=entry.get("area_id"),
+                labels=labels_tuple,
+            )
+        return entities
+
+    async def _fetch_device_registry(self) -> dict[str, DeviceInfo]:
+        """Fetch device registry data."""
+        result = await self.execute_hass_command(
+            "config/device_registry/list", {}, None
+        )
+        if not result.success or not isinstance(result.data, list):
+            return {}
+
+        devices: dict[str, DeviceInfo] = {}
+        for entry in result.data:
+            if not isinstance(entry, dict):
+                continue
+            device_id = entry.get("id")
+            if not isinstance(device_id, str):
+                continue
+
+            # Extract label IDs
+            label_ids = entry.get("labels", [])
+            if not isinstance(label_ids, list):
+                label_ids = []
+            labels_tuple = tuple(lid for lid in label_ids if isinstance(lid, str))
+
+            devices[device_id] = DeviceInfo(
+                name=entry.get("name") or entry.get("name_by_user"),
+                area_id=entry.get("area_id"),
+                labels=labels_tuple,
+            )
+        return devices
+
+    async def _fetch_area_registry(self) -> dict[str, AreaInfo]:
+        """Fetch area registry data."""
+        result = await self.execute_hass_command("config/area_registry/list", {}, None)
+        if not result.success or not isinstance(result.data, list):
+            return {}
+
+        areas: dict[str, AreaInfo] = {}
+        for entry in result.data:
+            if not isinstance(entry, dict):
+                continue
+            area_id = entry.get("area_id")
+            if not isinstance(area_id, str):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+
+            # Extract label IDs
+            label_ids = entry.get("labels", [])
+            if not isinstance(label_ids, list):
+                label_ids = []
+            labels_tuple = tuple(lid for lid in label_ids if isinstance(lid, str))
+
+            areas[area_id] = AreaInfo(
+                name=name,
+                floor_id=entry.get("floor_id"),
+                labels=labels_tuple,
+            )
+        return areas
+
+    async def _fetch_floor_registry(self) -> dict[str, FloorInfo]:
+        """Fetch floor registry data."""
+        result = await self.execute_hass_command("config/floor_registry/list", {}, None)
+        if not result.success or not isinstance(result.data, list):
+            return {}
+
+        floors: dict[str, FloorInfo] = {}
+        for entry in result.data:
+            if not isinstance(entry, dict):
+                continue
+            floor_id = entry.get("floor_id")
+            if not isinstance(floor_id, str):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            floors[floor_id] = FloorInfo(name=name)
+        return floors
+
+    async def _fetch_label_registry(self) -> dict[str, LabelInfo]:
+        """Fetch label registry data."""
+        result = await self.execute_hass_command("config/label_registry/list", {}, None)
+        if not result.success or not isinstance(result.data, list):
+            return {}
+
+        labels: dict[str, LabelInfo] = {}
+        for entry in result.data:
+            if not isinstance(entry, dict):
+                continue
+            label_id = entry.get("label_id")
+            if not isinstance(label_id, str):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            labels[label_id] = LabelInfo(name=name)
+        return labels
 
 
 class HamsterMCPView(HomeAssistantView):

--- a/src/hamster_mcp/mcp/_core/events.py
+++ b/src/hamster_mcp/mcp/_core/events.py
@@ -22,7 +22,12 @@ class FormatServiceResponse:
     """Format the raw HA service response into MCP content.
 
     Continuation type for service call results.
+
+    Attributes:
+        enrich: Whether to apply registry enrichment to the response.
     """
+
+    enrich: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,7 +35,12 @@ class FormatHassResponse:
     """Format the raw WebSocket command response into MCP content.
 
     Continuation type for hass command results.
+
+    Attributes:
+        enrich: Whether to apply registry enrichment to the response.
     """
+
+    enrich: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,7 +48,12 @@ class FormatSupervisorResponse:
     """Format the raw Supervisor API response into MCP content.
 
     Continuation type for supervisor call results.
+
+    Attributes:
+        enrich: Whether to apply registry enrichment to the response.
     """
+
+    enrich: bool = True
 
 
 # Continuation union - grows as new continuation types are added

--- a/src/hamster_mcp/mcp/_core/registry_enrichment.py
+++ b/src/hamster_mcp/mcp/_core/registry_enrichment.py
@@ -1,0 +1,273 @@
+"""Pure functions for enriching command output with registry data.
+
+Adds human-readable names from entity, device, area, floor, and label
+registries to command output JSON. Enrichment data is namespaced under
+a ``hamster_enrichment`` key to clearly distinguish it from original HA data.
+
+This module performs no I/O and holds no global state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class EntityInfo:
+    """Entity registry information."""
+
+    name: str | None
+    device_id: str | None
+    area_id: str | None
+    labels: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceInfo:
+    """Device registry information."""
+
+    name: str | None
+    area_id: str | None
+    labels: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AreaInfo:
+    """Area registry information."""
+
+    name: str
+    floor_id: str | None = None
+    labels: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class FloorInfo:
+    """Floor registry information."""
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class LabelInfo:
+    """Label registry information."""
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryContext:
+    """Container for all registry data needed for enrichment.
+
+    Constructed by the I/O layer from HA registry data, passed to pure
+    enrichment functions.
+    """
+
+    entities: dict[str, EntityInfo] = field(default_factory=dict)
+    devices: dict[str, DeviceInfo] = field(default_factory=dict)
+    areas: dict[str, AreaInfo] = field(default_factory=dict)
+    floors: dict[str, FloorInfo] = field(default_factory=dict)
+    labels: dict[str, LabelInfo] = field(default_factory=dict)
+
+    @classmethod
+    def empty(cls) -> RegistryContext:
+        """Create an empty registry context (no enrichment)."""
+        return cls()
+
+
+# Keys that trigger enrichment when found in a dict
+_ENTITY_ID_KEY = "entity_id"
+_DEVICE_ID_KEY = "device_id"
+_AREA_ID_KEY = "area_id"
+
+# Output key for enrichment data
+ENRICHMENT_KEY = "hamster_enrichment"
+
+
+def enrich_data(data: Any, context: RegistryContext) -> Any:
+    """Recursively enrich JSON data with registry information.
+
+    Traverses the data structure and adds ``hamster_enrichment`` objects
+    to dicts that contain entity_id, device_id, or area_id fields.
+
+    Args:
+        data: JSON-compatible data (dict, list, or scalar)
+        context: Registry data for lookups
+
+    Returns:
+        Enriched data with ``hamster_enrichment`` added where applicable.
+        Original data is not mutated; new objects are created.
+    """
+    if isinstance(data, dict):
+        return _enrich_dict(data, context)
+    if isinstance(data, list):
+        return [enrich_data(item, context) for item in data]
+    # Scalars pass through unchanged
+    return data
+
+
+def _enrich_dict(data: dict[str, Any], context: RegistryContext) -> dict[str, Any]:
+    """Enrich a dict, recursively processing nested structures.
+
+    Args:
+        data: Dict to enrich
+        context: Registry data for lookups
+
+    Returns:
+        New dict with enrichment added if applicable
+    """
+    # First, recursively enrich nested values
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        result[key] = enrich_data(value, context)
+
+    # Build enrichment for this dict
+    enrichment = _build_enrichment(data, context)
+    if enrichment:
+        result[ENRICHMENT_KEY] = enrichment
+
+    return result
+
+
+def _build_enrichment(
+    data: dict[str, Any],
+    context: RegistryContext,
+) -> dict[str, Any]:
+    """Build the hamster_enrichment object for a dict.
+
+    Args:
+        data: Original dict (before recursive enrichment)
+        context: Registry data for lookups
+
+    Returns:
+        Enrichment dict, or empty dict if no enrichment applies
+    """
+    enrichment: dict[str, Any] = {}
+
+    # Enrich by entity_id
+    entity_id = data.get(_ENTITY_ID_KEY)
+    if isinstance(entity_id, str):
+        _add_entity_enrichment(entity_id, enrichment, context)
+
+    # Enrich by device_id (only if not already enriched via entity)
+    device_id = data.get(_DEVICE_ID_KEY)
+    if isinstance(device_id, str) and "device_name" not in enrichment:
+        _add_device_enrichment(device_id, enrichment, context)
+
+    # Enrich by area_id (only if not already enriched via entity/device)
+    area_id = data.get(_AREA_ID_KEY)
+    if isinstance(area_id, str) and "area_name" not in enrichment:
+        _add_area_enrichment(area_id, enrichment, context)
+
+    return enrichment
+
+
+def _add_entity_enrichment(
+    entity_id: str,
+    enrichment: dict[str, Any],
+    context: RegistryContext,
+) -> None:
+    """Add entity-based enrichment fields.
+
+    Adds: name, device_name, area_name, floor_name, labels
+    """
+    entity = context.entities.get(entity_id)
+    if entity is None:
+        return
+
+    if entity.name:
+        enrichment["name"] = entity.name
+
+    # Resolve device
+    if entity.device_id:
+        device = context.devices.get(entity.device_id)
+        if device:
+            if device.name:
+                enrichment["device_name"] = device.name
+            # Device's area takes precedence if entity has no direct area
+            device_area_id = device.area_id
+        else:
+            device_area_id = None
+    else:
+        device_area_id = None
+
+    # Resolve area (entity's direct area, or fallback to device's area)
+    area_id = entity.area_id or device_area_id
+    if area_id:
+        _add_area_enrichment(area_id, enrichment, context)
+
+    # Resolve labels (combine entity and device labels)
+    all_labels = _resolve_labels(entity.labels, context)
+    if entity.device_id:
+        device = context.devices.get(entity.device_id)
+        if device:
+            device_labels = _resolve_labels(device.labels, context)
+            # Merge, keeping entity labels first
+            all_labels = list(dict.fromkeys(all_labels + device_labels))
+    if all_labels:
+        enrichment["labels"] = all_labels
+
+
+def _add_device_enrichment(
+    device_id: str,
+    enrichment: dict[str, Any],
+    context: RegistryContext,
+) -> None:
+    """Add device-based enrichment fields.
+
+    Adds: device_name, area_name, floor_name, labels
+    """
+    device = context.devices.get(device_id)
+    if device is None:
+        return
+
+    if device.name:
+        enrichment["device_name"] = device.name
+
+    if device.area_id:
+        _add_area_enrichment(device.area_id, enrichment, context)
+
+    labels = _resolve_labels(device.labels, context)
+    if labels:
+        enrichment["labels"] = labels
+
+
+def _add_area_enrichment(
+    area_id: str,
+    enrichment: dict[str, Any],
+    context: RegistryContext,
+) -> None:
+    """Add area-based enrichment fields.
+
+    Adds: area_name, floor_name
+    """
+    area = context.areas.get(area_id)
+    if area is None:
+        return
+
+    enrichment["area_name"] = area.name
+
+    if area.floor_id:
+        floor = context.floors.get(area.floor_id)
+        if floor:
+            enrichment["floor_name"] = floor.name
+
+
+def _resolve_labels(
+    label_ids: tuple[str, ...],
+    context: RegistryContext,
+) -> list[str]:
+    """Resolve label IDs to human-readable names.
+
+    Args:
+        label_ids: Tuple of label IDs
+        context: Registry data for lookups
+
+    Returns:
+        List of resolved label names (unresolved IDs are included as-is)
+    """
+    result: list[str] = []
+    for label_id in label_ids:
+        label = context.labels.get(label_id)
+        result.append(label.name if label else label_id)
+    return result

--- a/src/hamster_mcp/mcp/_core/registry_enrichment.py
+++ b/src/hamster_mcp/mcp/_core/registry_enrichment.py
@@ -196,16 +196,19 @@ def _add_entity_enrichment(
     if area_id:
         _add_area_enrichment(area_id, enrichment, context)
 
-    # Resolve labels (combine entity and device labels)
+    # Resolve labels (combine entity, device, and area labels)
+    # Start with entity labels
     all_labels = _resolve_labels(entity.labels, context)
+    # Add device labels
     if entity.device_id:
         device = context.devices.get(entity.device_id)
         if device:
             device_labels = _resolve_labels(device.labels, context)
-            # Merge, keeping entity labels first
             all_labels = list(dict.fromkeys(all_labels + device_labels))
-    if all_labels:
-        enrichment["labels"] = all_labels
+    # Merge with any labels already set (from area enrichment)
+    existing = enrichment.get("labels", [])
+    if all_labels or existing:
+        enrichment["labels"] = list(dict.fromkeys(all_labels + existing))
 
 
 def _add_device_enrichment(
@@ -239,7 +242,7 @@ def _add_area_enrichment(
 ) -> None:
     """Add area-based enrichment fields.
 
-    Adds: area_name, floor_name
+    Adds: area_name, floor_name, labels (merged with existing)
     """
     area = context.areas.get(area_id)
     if area is None:
@@ -251,6 +254,13 @@ def _add_area_enrichment(
         floor = context.floors.get(area.floor_id)
         if floor:
             enrichment["floor_name"] = floor.name
+
+    # Merge area labels with any existing labels
+    area_labels = _resolve_labels(area.labels, context)
+    if area_labels:
+        existing = enrichment.get("labels", [])
+        # Deduplicate while preserving order (existing first, then area labels)
+        enrichment["labels"] = list(dict.fromkeys([*existing, *area_labels]))
 
 
 def _resolve_labels(

--- a/src/hamster_mcp/mcp/_core/tools.py
+++ b/src/hamster_mcp/mcp/_core/tools.py
@@ -18,6 +18,7 @@ from .events import (
     FormatSupervisorResponse,
     ToolEffect,
 )
+from .registry_enrichment import RegistryContext, enrich_data
 from .resources import ResourceEntry
 from .resources import read_resource as _read_resource
 from .types import (
@@ -334,36 +335,46 @@ def _call_schema(arguments: dict[str, object], registry: GroupRegistry) -> ToolE
 def resume(
     continuation: Continuation,
     io_result: ServiceCallResult | HassCommandResult | SupervisorCallResult,
+    registry_context: RegistryContext | None = None,
 ) -> ToolEffect:
     """Resume tool execution after I/O completes.
 
     Args:
         continuation: The continuation from ServiceCall, HassCommand, or SupervisorCall
         io_result: Result of the I/O operation
+        registry_context: Optional registry data for enrichment. If None or
+            continuation.enrich is False, no enrichment is applied.
 
     Returns:
         Next ToolEffect (usually Done)
     """
+    # Determine effective context based on continuation's enrich flag
+    context = (
+        registry_context
+        if registry_context is not None and continuation.enrich
+        else RegistryContext.empty()
+    )
+
     if isinstance(continuation, FormatServiceResponse):
         if not isinstance(io_result, ServiceCallResult):
             return _make_error(
                 "Invalid IO result type for FormatServiceResponse"
             )  # pragma: no cover
-        return _format_service_response(io_result)
+        return _format_service_response(io_result, context)
 
     if isinstance(continuation, FormatHassResponse):
         if not isinstance(io_result, HassCommandResult):
             return _make_error(
                 "Invalid IO result type for FormatHassResponse"
             )  # pragma: no cover
-        return _format_hass_response(io_result)
+        return _format_hass_response(io_result, context)
 
     if isinstance(continuation, FormatSupervisorResponse):
         if not isinstance(io_result, SupervisorCallResult):
             return _make_error(
                 "Invalid IO result type for FormatSupervisorResponse"
             )  # pragma: no cover
-        return _format_supervisor_response(io_result)
+        return _format_supervisor_response(io_result, context)
 
     # Should not happen with proper typing, but handle gracefully
     return _make_error(
@@ -371,7 +382,10 @@ def resume(
     )  # pragma: no cover
 
 
-def _format_service_response(io_result: ServiceCallResult) -> Done:
+def _format_service_response(
+    io_result: ServiceCallResult,
+    context: RegistryContext,
+) -> Done:
     """Format a service call result into MCP content."""
     if not io_result.success:
         return Done(
@@ -382,14 +396,18 @@ def _format_service_response(io_result: ServiceCallResult) -> Done:
         )
 
     if io_result.data:
-        text = json.dumps(io_result.data, indent=2, default=str)
+        enriched = enrich_data(io_result.data, context)
+        text = json.dumps(enriched, indent=2, default=str)
     else:
         text = "Service call completed successfully."
 
     return Done(result=CallToolResult(content=(TextContent(text=text),)))
 
 
-def _format_hass_response(io_result: HassCommandResult) -> Done:
+def _format_hass_response(
+    io_result: HassCommandResult,
+    context: RegistryContext,
+) -> Done:
     """Format a WebSocket command result into MCP content."""
     if not io_result.success:
         return Done(
@@ -400,14 +418,18 @@ def _format_hass_response(io_result: HassCommandResult) -> Done:
         )
 
     if io_result.data is not None:
-        text = json.dumps(io_result.data, indent=2, default=str)
+        enriched = enrich_data(io_result.data, context)
+        text = json.dumps(enriched, indent=2, default=str)
     else:
         text = "Command completed successfully."
 
     return Done(result=CallToolResult(content=(TextContent(text=text),)))
 
 
-def _format_supervisor_response(io_result: SupervisorCallResult) -> Done:
+def _format_supervisor_response(
+    io_result: SupervisorCallResult,
+    context: RegistryContext,
+) -> Done:
     """Format a Supervisor API result into MCP content."""
     if not io_result.success:
         return Done(
@@ -422,7 +444,8 @@ def _format_supervisor_response(io_result: SupervisorCallResult) -> Done:
         if isinstance(io_result.data, str):
             text = io_result.data
         else:
-            text = json.dumps(io_result.data, indent=2, default=str)
+            enriched = enrich_data(io_result.data, context)
+            text = json.dumps(enriched, indent=2, default=str)
     else:
         text = "Supervisor call completed successfully."
 

--- a/src/hamster_mcp/mcp/_io/aiohttp.py
+++ b/src/hamster_mcp/mcp/_io/aiohttp.py
@@ -29,6 +29,7 @@ from hamster_mcp.mcp._core.events import (
     ServiceCall,
     SupervisorCall,
 )
+from hamster_mcp.mcp._core.registry_enrichment import RegistryContext  # noqa: TC001
 from hamster_mcp.mcp._core.tools import resume
 from hamster_mcp.mcp._core.types import (
     CallToolResult,
@@ -116,6 +117,18 @@ class EffectHandler(Protocol):
 
         Returns:
             SupervisorCallResult indicating success or failure
+        """
+        ...
+
+    async def fetch_registry_context(self) -> RegistryContext:
+        """Fetch registry data for enriching command outputs.
+
+        Retrieves entity, device, area, floor, and label registry data
+        from Home Assistant for use in enriching JSON outputs with
+        human-readable names.
+
+        Returns:
+            RegistryContext containing all registry data for lookups
         """
         ...
 
@@ -233,6 +246,11 @@ class AiohttpMCPTransport:
             Final CallToolResult
         """
         current = effect
+        # Fetch registry context once for the entire effect loop
+        # This context is used to enrich outputs with human-readable names
+        registry_context: RegistryContext | None = None
+        registry_context_fetched = False
+
         while True:
             if isinstance(current, Done):
                 return current.result
@@ -256,7 +274,11 @@ class AiohttpMCPTransport:
                         success=False,
                         error=f"Unexpected error: {type(err).__name__}: {err}",
                     )
-                current = resume(current.continuation, io_result)
+                # Fetch registry context if needed and not yet fetched
+                if current.continuation.enrich and not registry_context_fetched:
+                    registry_context = await self._fetch_registry_context_safe()
+                    registry_context_fetched = True
+                current = resume(current.continuation, io_result, registry_context)
             elif isinstance(current, HassCommand):
                 try:
                     hass_result = await self.effect_handler.execute_hass_command(
@@ -273,7 +295,11 @@ class AiohttpMCPTransport:
                         success=False,
                         error=f"Unexpected error: {type(err).__name__}: {err}",
                     )
-                current = resume(current.continuation, hass_result)
+                # Fetch registry context if needed and not yet fetched
+                if current.continuation.enrich and not registry_context_fetched:
+                    registry_context = await self._fetch_registry_context_safe()
+                    registry_context_fetched = True
+                current = resume(current.continuation, hass_result, registry_context)
             elif isinstance(current, SupervisorCall):
                 try:
                     supervisor_result = (
@@ -294,7 +320,25 @@ class AiohttpMCPTransport:
                         success=False,
                         error=f"Unexpected error: {type(err).__name__}: {err}",
                     )
-                current = resume(current.continuation, supervisor_result)
+                # Fetch registry context if needed and not yet fetched
+                if current.continuation.enrich and not registry_context_fetched:
+                    registry_context = await self._fetch_registry_context_safe()
+                    registry_context_fetched = True
+                current = resume(
+                    current.continuation, supervisor_result, registry_context
+                )
+
+    async def _fetch_registry_context_safe(self) -> RegistryContext | None:
+        """Fetch registry context, returning None on any error.
+
+        Errors during registry fetch should not fail the tool call -
+        enrichment is a nice-to-have, not a requirement.
+        """
+        try:
+            return await self.effect_handler.fetch_registry_context()
+        except Exception:
+            _LOGGER.warning("Failed to fetch registry context for enrichment")
+            return None
 
     def shutdown(self) -> None:
         """Shutdown the transport.

--- a/src/hamster_mcp/mcp/_tests/test_aiohttp.py
+++ b/src/hamster_mcp/mcp/_tests/test_aiohttp.py
@@ -29,6 +29,7 @@ from aiohttp.test_utils import TestClient, TestServer
 import pytest
 
 from hamster_mcp.mcp._core.groups import GroupRegistry, ServicesGroup
+from hamster_mcp.mcp._core.registry_enrichment import RegistryContext
 from hamster_mcp.mcp._core.session import SessionManager
 from hamster_mcp.mcp._core.supervisor_group import SupervisorGroup
 from hamster_mcp.mcp._core.types import (
@@ -123,6 +124,10 @@ class MockEffectHandler:
         if self.supervisor_should_raise is not None:
             raise self.supervisor_should_raise
         return self.supervisor_result
+
+    async def fetch_registry_context(self) -> RegistryContext:
+        """Fetch mock registry context for enrichment."""
+        return RegistryContext.empty()
 
 
 # Verify MockEffectHandler satisfies EffectHandler protocol

--- a/src/hamster_mcp/mcp/_tests/test_registry_enrichment.py
+++ b/src/hamster_mcp/mcp/_tests/test_registry_enrichment.py
@@ -56,7 +56,7 @@ def sample_context() -> RegistryContext:
             "area_living": AreaInfo(
                 name="Living Room",
                 floor_id="floor_1",
-                labels=(),
+                labels=("main_floor",),
             ),
             "area_bedroom": AreaInfo(
                 name="Bedroom",
@@ -77,6 +77,7 @@ def sample_context() -> RegistryContext:
             "smart_lights": LabelInfo(name="Smart Lights"),
             "downstairs": LabelInfo(name="Downstairs"),
             "zigbee": LabelInfo(name="Zigbee Devices"),
+            "main_floor": LabelInfo(name="Main Floor"),
         },
     )
 
@@ -122,6 +123,8 @@ class TestEnrichData:
         assert "Downstairs" in enrichment["labels"]
         # Device labels should also be included
         assert "Zigbee Devices" in enrichment["labels"]
+        # Area labels should also be included
+        assert "Main Floor" in enrichment["labels"]
 
     def test_enrich_entity_without_direct_area(
         self, sample_context: RegistryContext
@@ -168,13 +171,14 @@ class TestEnrichData:
         assert enrichment["floor_name"] == "Ground Floor"
 
     def test_enrich_area_id(self, sample_context: RegistryContext) -> None:
-        """Area ID enrichment adds area_name and floor_name."""
+        """Area ID enrichment adds area_name, floor_name, and labels."""
         data = {"area_id": "area_living", "entity_count": 5}
         result = enrich_data(data, sample_context)
 
         enrichment = result[ENRICHMENT_KEY]
         assert enrichment["area_name"] == "Living Room"
         assert enrichment["floor_name"] == "Ground Floor"
+        assert "Main Floor" in enrichment["labels"]
 
     def test_entity_takes_precedence_over_device(
         self, sample_context: RegistryContext

--- a/src/hamster_mcp/mcp/_tests/test_registry_enrichment.py
+++ b/src/hamster_mcp/mcp/_tests/test_registry_enrichment.py
@@ -1,0 +1,291 @@
+"""Tests for registry_enrichment module."""
+
+from __future__ import annotations
+
+import pytest
+
+from hamster_mcp.mcp._core.registry_enrichment import (
+    ENRICHMENT_KEY,
+    AreaInfo,
+    DeviceInfo,
+    EntityInfo,
+    FloorInfo,
+    LabelInfo,
+    RegistryContext,
+    enrich_data,
+)
+
+
+@pytest.fixture
+def sample_context() -> RegistryContext:
+    """Create a sample registry context for testing."""
+    return RegistryContext(
+        entities={
+            "light.living_room": EntityInfo(
+                name="Living Room Ceiling Light",
+                device_id="device_123",
+                area_id="area_living",
+                labels=("smart_lights", "downstairs"),
+            ),
+            "sensor.temperature": EntityInfo(
+                name="Temperature Sensor",
+                device_id="device_456",
+                area_id=None,  # No direct area, uses device's area
+                labels=(),
+            ),
+            "switch.no_device": EntityInfo(
+                name="Standalone Switch",
+                device_id=None,
+                area_id="area_kitchen",
+                labels=(),
+            ),
+        },
+        devices={
+            "device_123": DeviceInfo(
+                name="Philips Hue Bridge",
+                area_id="area_living",
+                labels=("zigbee",),
+            ),
+            "device_456": DeviceInfo(
+                name="Aqara Hub",
+                area_id="area_bedroom",
+                labels=(),
+            ),
+        },
+        areas={
+            "area_living": AreaInfo(
+                name="Living Room",
+                floor_id="floor_1",
+                labels=(),
+            ),
+            "area_bedroom": AreaInfo(
+                name="Bedroom",
+                floor_id="floor_2",
+                labels=(),
+            ),
+            "area_kitchen": AreaInfo(
+                name="Kitchen",
+                floor_id="floor_1",
+                labels=(),
+            ),
+        },
+        floors={
+            "floor_1": FloorInfo(name="Ground Floor"),
+            "floor_2": FloorInfo(name="First Floor"),
+        },
+        labels={
+            "smart_lights": LabelInfo(name="Smart Lights"),
+            "downstairs": LabelInfo(name="Downstairs"),
+            "zigbee": LabelInfo(name="Zigbee Devices"),
+        },
+    )
+
+
+class TestEnrichData:
+    """Tests for the enrich_data function."""
+
+    def test_scalar_passthrough(self, sample_context: RegistryContext) -> None:
+        """Scalar values pass through unchanged."""
+        assert enrich_data("hello", sample_context) == "hello"
+        assert enrich_data(42, sample_context) == 42
+        assert enrich_data(3.14, sample_context) == 3.14
+        assert enrich_data(True, sample_context) is True
+        assert enrich_data(None, sample_context) is None
+
+    def test_empty_dict(self, sample_context: RegistryContext) -> None:
+        """Empty dict returns empty dict."""
+        assert enrich_data({}, sample_context) == {}
+
+    def test_dict_without_enrichable_keys(
+        self, sample_context: RegistryContext
+    ) -> None:
+        """Dict without entity_id/device_id/area_id is unchanged."""
+        data = {"state": "on", "brightness": 255}
+        result = enrich_data(data, sample_context)
+        assert result == {"state": "on", "brightness": 255}
+
+    def test_enrich_entity_id(self, sample_context: RegistryContext) -> None:
+        """Entity ID enrichment adds name, device, area, floor, labels."""
+        data = {"entity_id": "light.living_room", "state": "on"}
+        result = enrich_data(data, sample_context)
+
+        assert result["entity_id"] == "light.living_room"
+        assert result["state"] == "on"
+        assert ENRICHMENT_KEY in result
+
+        enrichment = result[ENRICHMENT_KEY]
+        assert enrichment["name"] == "Living Room Ceiling Light"
+        assert enrichment["device_name"] == "Philips Hue Bridge"
+        assert enrichment["area_name"] == "Living Room"
+        assert enrichment["floor_name"] == "Ground Floor"
+        assert "Smart Lights" in enrichment["labels"]
+        assert "Downstairs" in enrichment["labels"]
+        # Device labels should also be included
+        assert "Zigbee Devices" in enrichment["labels"]
+
+    def test_enrich_entity_without_direct_area(
+        self, sample_context: RegistryContext
+    ) -> None:
+        """Entity without direct area uses device's area."""
+        data = {"entity_id": "sensor.temperature"}
+        result = enrich_data(data, sample_context)
+
+        enrichment = result[ENRICHMENT_KEY]
+        assert enrichment["name"] == "Temperature Sensor"
+        assert enrichment["device_name"] == "Aqara Hub"
+        # Should use device's area since entity has no direct area
+        assert enrichment["area_name"] == "Bedroom"
+        assert enrichment["floor_name"] == "First Floor"
+
+    def test_enrich_entity_without_device(
+        self, sample_context: RegistryContext
+    ) -> None:
+        """Entity without device still enriches area."""
+        data = {"entity_id": "switch.no_device"}
+        result = enrich_data(data, sample_context)
+
+        enrichment = result[ENRICHMENT_KEY]
+        assert enrichment["name"] == "Standalone Switch"
+        assert "device_name" not in enrichment
+        assert enrichment["area_name"] == "Kitchen"
+
+    def test_unknown_entity_id(self, sample_context: RegistryContext) -> None:
+        """Unknown entity_id produces no enrichment."""
+        data = {"entity_id": "light.unknown", "state": "off"}
+        result = enrich_data(data, sample_context)
+
+        # No enrichment key when entity not found
+        assert result == {"entity_id": "light.unknown", "state": "off"}
+
+    def test_enrich_device_id(self, sample_context: RegistryContext) -> None:
+        """Device ID enrichment adds device_name, area, floor."""
+        data = {"device_id": "device_123", "manufacturer": "Philips"}
+        result = enrich_data(data, sample_context)
+
+        enrichment = result[ENRICHMENT_KEY]
+        assert enrichment["device_name"] == "Philips Hue Bridge"
+        assert enrichment["area_name"] == "Living Room"
+        assert enrichment["floor_name"] == "Ground Floor"
+
+    def test_enrich_area_id(self, sample_context: RegistryContext) -> None:
+        """Area ID enrichment adds area_name and floor_name."""
+        data = {"area_id": "area_living", "entity_count": 5}
+        result = enrich_data(data, sample_context)
+
+        enrichment = result[ENRICHMENT_KEY]
+        assert enrichment["area_name"] == "Living Room"
+        assert enrichment["floor_name"] == "Ground Floor"
+
+    def test_entity_takes_precedence_over_device(
+        self, sample_context: RegistryContext
+    ) -> None:
+        """When both entity_id and device_id present, entity enrichment is used."""
+        data = {
+            "entity_id": "light.living_room",
+            "device_id": "device_456",  # Different device
+        }
+        result = enrich_data(data, sample_context)
+
+        enrichment = result[ENRICHMENT_KEY]
+        # Should use entity's device, not the explicit device_id
+        assert enrichment["device_name"] == "Philips Hue Bridge"
+
+    def test_enrich_list(self, sample_context: RegistryContext) -> None:
+        """List of dicts are each enriched."""
+        data = [
+            {"entity_id": "light.living_room", "state": "on"},
+            {"entity_id": "sensor.temperature", "state": "21"},
+        ]
+        result = enrich_data(data, sample_context)
+
+        assert len(result) == 2
+        assert result[0][ENRICHMENT_KEY]["name"] == "Living Room Ceiling Light"
+        assert result[1][ENRICHMENT_KEY]["name"] == "Temperature Sensor"
+
+    def test_enrich_nested_structure(self, sample_context: RegistryContext) -> None:
+        """Nested structures are recursively enriched."""
+        data = {
+            "result": {
+                "entities": [
+                    {"entity_id": "light.living_room"},
+                ]
+            }
+        }
+        result = enrich_data(data, sample_context)
+
+        # The nested entity should be enriched
+        entity = result["result"]["entities"][0]
+        assert ENRICHMENT_KEY in entity
+        assert entity[ENRICHMENT_KEY]["name"] == "Living Room Ceiling Light"
+
+    def test_empty_context(self) -> None:
+        """Empty context produces no enrichment."""
+        empty_context = RegistryContext.empty()
+        data = {"entity_id": "light.living_room", "state": "on"}
+        result = enrich_data(data, empty_context)
+
+        # No enrichment when context is empty
+        assert result == {"entity_id": "light.living_room", "state": "on"}
+
+    def test_unresolved_label_ids(self) -> None:
+        """Unresolved label IDs are included as-is."""
+        context = RegistryContext(
+            entities={
+                "light.test": EntityInfo(
+                    name="Test Light",
+                    device_id=None,
+                    area_id=None,
+                    labels=("known_label", "unknown_label"),
+                ),
+            },
+            labels={
+                "known_label": LabelInfo(name="Known Label"),
+                # unknown_label not in registry
+            },
+        )
+        data = {"entity_id": "light.test"}
+        result = enrich_data(data, context)
+
+        enrichment = result[ENRICHMENT_KEY]
+        # Known label is resolved, unknown is kept as ID
+        assert "Known Label" in enrichment["labels"]
+        assert "unknown_label" in enrichment["labels"]
+
+
+class TestRegistryContext:
+    """Tests for RegistryContext dataclass."""
+
+    def test_empty_factory(self) -> None:
+        """RegistryContext.empty() creates empty context."""
+        ctx = RegistryContext.empty()
+        assert ctx.entities == {}
+        assert ctx.devices == {}
+        assert ctx.areas == {}
+        assert ctx.floors == {}
+        assert ctx.labels == {}
+
+    def test_frozen(self) -> None:
+        """RegistryContext is immutable."""
+        ctx = RegistryContext.empty()
+        with pytest.raises(AttributeError):
+            ctx.entities = {}  # type: ignore[misc]
+
+
+class TestInfoDataclasses:
+    """Tests for the Info dataclasses."""
+
+    def test_entity_info_defaults(self) -> None:
+        """EntityInfo has proper defaults."""
+        info = EntityInfo(name=None, device_id=None, area_id=None)
+        assert info.labels == ()
+
+    def test_device_info_defaults(self) -> None:
+        """DeviceInfo has proper defaults."""
+        info = DeviceInfo(name=None, area_id=None)
+        assert info.labels == ()
+
+    def test_area_info_defaults(self) -> None:
+        """AreaInfo has proper defaults."""
+        info = AreaInfo(name="Test")
+        assert info.floor_id is None
+        assert info.labels == ()


### PR DESCRIPTION
## Summary

Implements the registry enrichment layer described in the architecture docs (resolves #50).

Command outputs now include a `hamster_enrichment` object containing human-readable names from entity, device, area, floor, and label registries. This helps LLMs understand relationships between entities when composing service calls.

## Changes

- **New module**: `src/hamster_mcp/mcp/_core/registry_enrichment.py`
  - Pure functions for enriching JSON data with registry information
  - `RegistryContext` dataclass holding all registry data
  - `enrich_data()` recursively traverses data and adds enrichment

- **Continuation types** (`events.py`): Added `enrich: bool = True` flag to control enrichment per-command

- **Formatting functions** (`tools.py`): Updated to accept `RegistryContext` and apply enrichment

- **I/O layer** (`aiohttp.py`): 
  - `EffectHandler` protocol gains `fetch_registry_context()` method
  - Effect dispatch loop fetches registries when needed

- **Effect handler** (`component/http.py`): 
  - Implements `fetch_registry_context()` using HA's WebSocket API
  - Fetches entity, device, area, floor, and label registries in parallel

## Example Output

```json
{
  "entity_id": "light.living_room",
  "state": "on",
  "hamster_enrichment": {
    "name": "Living Room Ceiling Light",
    "device_name": "Philips Hue Bridge",
    "area_name": "Living Room",
    "floor_name": "Ground Floor",
    "labels": ["Smart Lights", "Downstairs"]
  }
}
```

## Testing

- 19 new tests for registry enrichment module
- All 631 tests pass
- ruff, mypy checks pass