### PR TITLE
Add discriminator-style annotations to schema/explain tools

### DIFF
--- a/src/hamster_mcp/mcp/_core/groups.py
+++ b/src/hamster_mcp/mcp/_core/groups.py
@@ -466,11 +466,12 @@ class ServicesGroup:
             chunk = SELECTOR_TYPES[i : i + types_per_line]
             type_lines.append(", ".join(chunk))
 
+        newline = "\n"
         markdown = f"""## Available Selector Types
 
 {len(SELECTOR_TYPES)} selector types available:
 
-{chr(10).join(f"- {line}" for line in type_lines)}
+{newline.join(f"- {line}" for line in type_lines)}
 
 Use `schema("selector/<type>")` to get the JSON Schema for a specific type."""
 

--- a/src/hamster_mcp/mcp/_core/groups.py
+++ b/src/hamster_mcp/mcp/_core/groups.py
@@ -6,6 +6,7 @@ command sources (services, hass, supervisor).
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 import json
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -568,7 +569,7 @@ Use `schema("selector/<type>")` to get the JSON Schema for a specific type."""
                 # Get base schema from selector type
                 base_schema = get_selector_schema(selector_type)
                 if base_schema:
-                    field_schema = base_schema.copy()
+                    field_schema = copy.deepcopy(base_schema)
                 else:
                     field_schema["x-selector-type"] = selector_type
 

--- a/src/hamster_mcp/mcp/_core/groups.py
+++ b/src/hamster_mcp/mcp/_core/groups.py
@@ -7,9 +7,15 @@ command sources (services, hass, supervisor).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import json
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from .events import Done, FormatServiceResponse, ServiceCall, ToolEffect
+from .selector_schemas import (
+    SELECTOR_TYPES,
+    get_selector_list_schema,
+    get_selector_schema,
+)
 from .types import CallToolResult, TextContent
 
 if TYPE_CHECKING:
@@ -298,6 +304,7 @@ class ServicesGroup:
 
         Returns:
             Formatted text with full service details, or None if not found.
+            Includes references to relevant JSON Schemas for type exploration.
         """
         if "." not in path:
             return None
@@ -325,6 +332,7 @@ class ServicesGroup:
         if target:
             lines.append("")
             lines.append("### Target")
+            lines.append('*(use `schema("selector/target")` for full JSON Schema)*')
             if isinstance(target, dict):
                 if entity := target.get("entity"):
                     lines.append(f"- Entity: {entity}")
@@ -337,10 +345,24 @@ class ServicesGroup:
 
         # Fields
         fields = service_data.get("fields")
+        selector_types_used: set[str] = set()
         if isinstance(fields, dict) and fields:
             lines.append("")
             lines.append("### Fields")
-            self._format_fields(fields, lines)
+            self._format_fields(fields, lines, selector_types_used=selector_types_used)
+
+        # Schema references section
+        if selector_types_used or target:
+            lines.append("")
+            lines.append("### Schema References")
+            lines.append(
+                f'Use `schema("{domain}.{service}")` '
+                "for full JSON Schema of parameters."
+            )
+            if selector_types_used:
+                sorted_types = sorted(selector_types_used)
+                refs = ", ".join(f'`schema("selector/{t}")`' for t in sorted_types)
+                lines.append(f"Selector types used: {refs}")
 
         return "\n".join(lines)
 
@@ -349,8 +371,17 @@ class ServicesGroup:
         fields: dict[str, object],
         lines: list[str],
         indent: str = "",
+        *,
+        selector_types_used: set[str] | None = None,
     ) -> None:
-        """Format field definitions recursively."""
+        """Format field definitions recursively.
+
+        Args:
+            fields: Field definitions dict
+            lines: Output lines to append to
+            indent: Current indentation string
+            selector_types_used: Set to collect selector types encountered
+        """
         for field_name, field_data in fields.items():
             if not isinstance(field_data, dict):
                 continue
@@ -361,7 +392,12 @@ class ServicesGroup:
                 lines.append(f"{indent}- **{section_name}** (section)")
                 nested_fields = field_data.get("fields")
                 if isinstance(nested_fields, dict):
-                    self._format_fields(nested_fields, lines, indent + "  ")
+                    self._format_fields(
+                        nested_fields,
+                        lines,
+                        indent + "  ",
+                        selector_types_used=selector_types_used,
+                    )
                 continue
 
             # Regular field
@@ -374,7 +410,10 @@ class ServicesGroup:
             if isinstance(selector, dict) and selector:
                 selector_types = list(selector.keys())
                 if selector_types:
-                    selector_info = f" [{selector_types[0]}]"
+                    selector_type = selector_types[0]
+                    selector_info = f" [{selector_type}]"
+                    if selector_types_used is not None:
+                        selector_types_used.add(selector_type)
 
             base = f"{indent}- **{field_name}**{req_marker}{selector_info}"
             if isinstance(field_desc, str) and field_desc:
@@ -385,13 +424,21 @@ class ServicesGroup:
     def schema(self, path: str) -> str | None:
         """Get schema/type info for a service or selector.
 
-        For selectors, use path like "selector/duration".
-        For services, use path like "light.turn_on" to get field schema.
+        Returns a hybrid JSON Schema + Markdown response:
+        - JSON Schema in a code block for machine parsing
+        - Markdown description for human readability
+
+        Path formats:
+        - "selector" - List all selector types (x-selector-types annotation)
+        - "selector/<type>" - Get JSON Schema for a specific selector
+        - "domain.service" - Get JSON Schema for service parameters
         """
-        # Check for selector path
+        # Handle selector paths
+        if path == "selector":
+            return self._format_selector_list_schema()
         if path.startswith("selector/"):
             selector_type = path[9:]  # Remove "selector/" prefix
-            return self._describe_selector(selector_type)
+            return self._format_selector_schema(selector_type)
 
         # Service field schema
         if "." not in path:
@@ -406,101 +453,172 @@ class ServicesGroup:
         if not isinstance(service_data, dict):
             return None
 
-        # Format field schema
+        return self._format_service_schema(domain, service, service_data)
+
+    def _format_selector_list_schema(self) -> str:
+        """Format the selector type list with x-selector-types annotation."""
+        schema = get_selector_list_schema()
+        json_block = json.dumps(schema, indent=2)
+
+        types_per_line = 8
+        type_lines = []
+        for i in range(0, len(SELECTOR_TYPES), types_per_line):
+            chunk = SELECTOR_TYPES[i : i + types_per_line]
+            type_lines.append(", ".join(chunk))
+
+        markdown = f"""## Available Selector Types
+
+{len(SELECTOR_TYPES)} selector types available:
+
+{chr(10).join(f"- {line}" for line in type_lines)}
+
+Use `schema("selector/<type>")` to get the JSON Schema for a specific type."""
+
+        return f"```json\n{json_block}\n```\n\n{markdown}"
+
+    def _format_selector_schema(self, selector_type: str) -> str:
+        """Format a single selector type's JSON Schema."""
+        schema = get_selector_schema(selector_type)
+
+        if schema is None:
+            return (
+                f"Unknown selector type: {selector_type}\n\n"
+                f'Use `schema("selector")` to see all {len(SELECTOR_TYPES)} '
+                "available selector types."
+            )
+
+        json_block = json.dumps(schema, indent=2)
+        description = schema.get("description", "")
+
+        # Build markdown explanation
+        markdown_parts = [f"## {selector_type} selector", ""]
+        if description:
+            markdown_parts.append(description)
+            markdown_parts.append("")
+
+        # Add type-specific notes
+        schema_type = schema.get("type", "any")
+        if schema_type == "object" and "properties" in schema:
+            props = schema["properties"]
+            required = schema.get("required", [])
+            markdown_parts.append("**Properties:**")
+            for prop_name, prop_schema in props.items():
+                req_marker = " (required)" if prop_name in required else ""
+                prop_desc = prop_schema.get("description", "")
+                if isinstance(prop_schema, dict) and "oneOf" in prop_schema:
+                    prop_desc = prop_schema.get("description", "string or array")
+                markdown_parts.append(f"- `{prop_name}`{req_marker}: {prop_desc}")
+            markdown_parts.append("")
+
+        # Add x-target-keys note for target selector
+        if "x-target-keys" in schema:
+            target_keys = schema["x-target-keys"]
+            markdown_parts.append(
+                f"**Target keys:** {', '.join(f'`{k}`' for k in target_keys)}"
+            )
+            markdown_parts.append("")
+
+        # Add examples if present
+        if "examples" in schema:
+            examples = schema["examples"]
+            markdown_parts.append("**Examples:**")
+            for ex in examples:
+                if isinstance(ex, str):
+                    markdown_parts.append(f"- `{ex}`")
+                else:
+                    markdown_parts.append(f"- `{json.dumps(ex)}`")
+
+        return f"```json\n{json_block}\n```\n\n" + "\n".join(markdown_parts)
+
+    def _format_service_schema(
+        self, domain: str, service: str, service_data: dict[str, object]
+    ) -> str:
+        """Format service parameters as JSON Schema."""
         fields = service_data.get("fields")
         if not isinstance(fields, dict) or not fields:
             return f"Service {domain}.{service} has no parameters."
 
-        lines = [f"## {domain}.{service} Parameters", ""]
+        # Build JSON Schema for service parameters
+        properties: dict[str, Any] = {}
+        required_fields: list[str] = []
+
         for field_name, field_data in fields.items():
             if not isinstance(field_data, dict):
                 continue
 
-            required = field_data.get("required", False)
+            # Skip sections (nested field groups) for now
+            if "fields" in field_data:
+                continue
+
+            is_required = field_data.get("required", False)
             selector = field_data.get("selector", {})
             desc = field_data.get("description", "")
 
-            req_str = " (required)" if required else ""
-            selector_str = ""
+            # Determine selector type
+            selector_type = None
             if isinstance(selector, dict) and selector:
-                selector_types = list(selector.keys())
-                if selector_types:
-                    selector_str = f" - type: {selector_types[0]}"
+                selector_keys = list(selector.keys())
+                if selector_keys:
+                    selector_type = selector_keys[0]
 
-            lines.append(f"- **{field_name}**{req_str}{selector_str}")
+            # Build field schema
+            field_schema: dict[str, Any] = {}
+            if selector_type:
+                # Get base schema from selector type
+                base_schema = get_selector_schema(selector_type)
+                if base_schema:
+                    field_schema = base_schema.copy()
+                else:
+                    field_schema["x-selector-type"] = selector_type
+
+            # Override description with service-specific one
             if isinstance(desc, str) and desc:
-                lines.append(f"  {desc}")
+                field_schema["description"] = desc
 
-        return "\n".join(lines)
+            properties[field_name] = field_schema
 
-    def _describe_selector(self, selector_type: str) -> str:
-        """Look up description for a selector type."""
-        descriptions = {
-            "action": "An automation action sequence (list of action objects)",
-            "addon": "Home Assistant add-on slug (string)",
-            "area": "Area ID string (e.g. 'living_room')",
-            "assist_pipeline": "Assist pipeline ID (string)",
-            "attribute": "Entity attribute name (string)",
-            "backup_location": "Backup location identifier (string)",
-            "boolean": "true or false",
-            "color_rgb": "Array of 3 integers [R, G, B], each 0-255",
-            "color_temp": "Color temperature in mireds (integer) or Kelvin",
-            "condition": "An automation condition (condition object)",
-            "config_entry": "Config entry ID (string)",
-            "constant": "A fixed constant value",
-            "conversation_agent": "Conversation agent ID (string)",
-            "country": "ISO 3166-1 alpha-2 country code (string, e.g. 'US')",
-            "date": "Date string in ISO format (YYYY-MM-DD)",
-            "datetime": "Date and time string in ISO format (YYYY-MM-DDTHH:MM:SS)",
-            "device": "Device ID string",
-            "duration": (
-                "Dict with optional keys: days, hours, minutes, seconds, milliseconds "
-                '(all numbers). Example: {"hours": 1, "minutes": 30}'
-            ),
-            "entity": "Entity ID string (e.g. 'light.living_room')",
-            "file": "File path or file content",
-            "floor": "Floor ID string",
-            "icon": "Material Design Icon name (string, e.g. 'mdi:lightbulb')",
-            "label": "Label ID string",
-            "language": "Language code (string, e.g. 'en')",
-            "location": (
-                "Dict with latitude, longitude (required), and radius (optional). "
-                'Example: {"latitude": 40.7, "longitude": -74.0}'
-            ),
-            "media": "Media content ID and type",
-            "navigation": "Navigation path within Home Assistant",
-            "number": (
-                "Numeric value; may have min/max/step constraints "
-                "defined by the service"
-            ),
-            "object": "Arbitrary JSON object",
-            "qr_code": "QR code data (string)",
-            "schedule": "Schedule definition object",
-            "select": "One of a fixed set of string options (see service description)",
-            "selector": "A selector definition object",
-            "state": "Entity state value (string)",
-            "statistic": "Statistic ID (string)",
-            "stt": "Speech-to-text engine ID (string)",
-            "target": (
-                "Dict with optional keys: entity_id, device_id, area_id, floor_id, "
-                "label_id (each can be a string or array of strings)"
-            ),
-            "template": "Jinja2 template string",
-            "text": "String value; may have multiline or regex constraints",
-            "theme": "Theme name (string)",
-            "time": "Time string in HH:MM:SS format",
-            "trigger": "An automation trigger definition",
-            "tts": "Text-to-speech engine ID (string)",
-            "ui_action": "UI action definition",
-            "ui_color": "UI color value",
+            if is_required:
+                required_fields.append(field_name)
+
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": properties,
         }
+        if required_fields:
+            schema["required"] = required_fields
 
-        if selector_type in descriptions:
-            return f"{selector_type}: {descriptions[selector_type]}"
-        return (
-            f"{selector_type}: Unknown selector type. "
-            "Check Home Assistant documentation."
-        )
+        json_block = json.dumps(schema, indent=2)
+
+        # Build markdown summary
+        markdown_parts = [f"## {domain}.{service} Parameters", ""]
+
+        for field_name, field_data in fields.items():
+            if not isinstance(field_data, dict):
+                continue
+
+            # Handle sections
+            if "fields" in field_data:
+                section_name = field_data.get("name", field_name)
+                markdown_parts.append(f"**{section_name}** (section)")
+                continue
+
+            is_required = field_data.get("required", False)
+            selector = field_data.get("selector", {})
+            desc = field_data.get("description", "")
+
+            selector_type = ""
+            if isinstance(selector, dict) and selector:
+                selector_keys = list(selector.keys())
+                if selector_keys:
+                    selector_type = f" [{selector_keys[0]}]"
+
+            req_str = " (required)" if is_required else ""
+            line = f"- **{field_name}**{req_str}{selector_type}"
+            if isinstance(desc, str) and desc:
+                line += f": {desc}"
+            markdown_parts.append(line)
+
+        return f"```json\n{json_block}\n```\n\n" + "\n".join(markdown_parts)
 
     def has_command(self, path: str) -> bool:
         """Check if a service exists."""

--- a/src/hamster_mcp/mcp/_core/resources/insights/selectors.md
+++ b/src/hamster_mcp/mcp/_core/resources/insights/selectors.md
@@ -1,16 +1,50 @@
 # Selectors
 
-Selector types define the expected value format for service call fields.  Use
+Selector types define the expected value format for service call fields. Use
 `schema` with a service path to see the selectors for its fields, or
-`schema` with `services/selector/<type>` to get details on a specific selector
-type.
+`schema` with `services/selector/<type>` to get the JSON Schema for a specific
+selector type.
 
 ## Overview
 
 When you `explain` or `schema` a service, each field includes a selector that
-describes what kind of value it expects.  Selectors are the bridge between
+describes what kind of value it expects. Selectors are the bridge between
 the HA UI (which renders appropriate input widgets) and the API (which expects
 correctly typed values).
+
+## Discovering Selector Types
+
+Use `schema("selector")` to get a list of all available selector types:
+
+```json
+{
+  "x-selector-types": ["action", "area", "boolean", "color_rgb", ...],
+  "description": "Use schema('selector/<type>') for full JSON Schema..."
+}
+```
+
+The `x-selector-types` annotation lists all valid selector type names.
+
+## JSON Schema Output
+
+Each selector type has a JSON Schema definition. For example,
+`schema("selector/duration")` returns:
+
+```json
+{
+  "type": "object",
+  "x-selector-type": "duration",
+  "description": "Time duration with optional components",
+  "properties": {
+    "days": {"type": "number", "minimum": 0},
+    "hours": {"type": "number", "minimum": 0},
+    "minutes": {"type": "number", "minimum": 0},
+    "seconds": {"type": "number", "minimum": 0}
+  }
+}
+```
+
+The `x-selector-type` annotation identifies the selector type name.
 
 ## Common Selector Types
 
@@ -28,7 +62,7 @@ Expects: `true` or `false`
 {"selector": {"number": {"min": 0, "max": 255, "step": 1, "mode": "slider"}}}
 ```
 
-Expects: A numeric value within the specified range.  If `step` is `1` and
+Expects: A numeric value within the specified range. If `step` is `1` and
 no fractional bounds exist, an integer is expected.
 
 ### Text
@@ -56,11 +90,11 @@ field in the API call.
 {"selector": {"entity": {"domain": "light", "multiple": true}}}
 ```
 
-Expects: An entity ID string (or array if `multiple` is true).  The `domain`
+Expects: An entity ID string (or array if `multiple` is true). The `domain`
 field constrains which entity domains are valid.
 
 Note: Entity selectors in `data` fields are different from the `target`
-parameter.  Some services use entity selectors in data fields for
+parameter. Some services use entity selectors in data fields for
 secondary entity references (e.g., "play media from this source entity").
 
 ### Device
@@ -69,7 +103,7 @@ secondary entity references (e.g., "play media from this source entity").
 {"selector": {"device": {"integration": "hue"}}}
 ```
 
-Expects: A device ID string.  The `integration` field constrains which
+Expects: A device ID string. The `integration` field constrains which
 integrations are valid.
 
 ### Area
@@ -78,7 +112,7 @@ integrations are valid.
 {"selector": {"area": {"entity": {"domain": "light"}}}}
 ```
 
-Expects: An area ID string.  Optional filters constrain which areas are
+Expects: An area ID string. Optional filters constrain which areas are
 shown based on the entities or devices they contain.
 
 ### Target
@@ -90,13 +124,16 @@ shown based on the entities or devices they contain.
 Expects: A target object (see the Service Targeting insight document).
 This is the most common way services declare their targeting requirements.
 
+The target schema includes an `x-target-keys` annotation listing valid keys:
+`entity_id`, `device_id`, `area_id`, `floor_id`, `label_id`.
+
 ### Color Temperature
 
 ```json
 {"selector": {"color_temp": {"min_mireds": 153, "max_mireds": 500}}}
 ```
 
-Expects: An integer value in mireds (micro reciprocal degrees).  Lower values
+Expects: An integer value in mireds (micro reciprocal degrees). Lower values
 are cooler (bluer), higher values are warmer (yellower).
 
 ### Color (RGB)
@@ -139,7 +176,7 @@ Expects: An object with optional `hours`, `minutes`, `seconds` keys:
 {"selector": {"object": {}}}
 ```
 
-Expects: Any JSON object.  Used for free-form structured data.
+Expects: Any JSON object. Used for free-form structured data.
 
 ### Template
 
@@ -153,21 +190,30 @@ Example: `"{{ states('sensor.temperature') | float > 25 }}"`
 
 ## Using Schema to Explore Selectors
 
-To see all details for a specific selector type:
+**List all selector types:**
 
 ```json
-{
-  "path": "services/selector/duration"
-}
+{"path": "services/selector"}
 ```
 
-To see the field selectors for a specific service:
+Returns `x-selector-types` array with all available types.
+
+**Get JSON Schema for a specific selector:**
 
 ```json
-{
-  "path": "services/climate.set_temperature"
-}
+{"path": "services/selector/duration"}
 ```
+
+Returns full JSON Schema with type, properties, and constraints.
+
+**Get JSON Schema for a service's parameters:**
+
+```json
+{"path": "services/climate.set_temperature"}
+```
+
+Returns JSON Schema with all fields, their types, and required status.
 
 The schema output shows each field's selector type, constraints (min/max,
-options, domain filters), and whether the field is required.
+options, domain filters), and whether the field is required. Fields include
+`x-selector-type` annotations to identify which selector type applies.

--- a/src/hamster_mcp/mcp/_core/resources/insights/selectors.md
+++ b/src/hamster_mcp/mcp/_core/resources/insights/selectors.md
@@ -39,7 +39,8 @@ Each selector type has a JSON Schema definition. For example,
     "days": {"type": "number", "minimum": 0},
     "hours": {"type": "number", "minimum": 0},
     "minutes": {"type": "number", "minimum": 0},
-    "seconds": {"type": "number", "minimum": 0}
+    "seconds": {"type": "number", "minimum": 0},
+    "milliseconds": {"type": "number", "minimum": 0}
   }
 }
 ```

--- a/src/hamster_mcp/mcp/_core/selector_schemas.py
+++ b/src/hamster_mcp/mcp/_core/selector_schemas.py
@@ -15,6 +15,7 @@ This module provides:
 
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 
@@ -339,5 +340,6 @@ def get_target_schema() -> dict[str, Any]:
     """Get the JSON Schema for the target specification.
 
     This is the discriminated union for service targeting.
+    Returns a deep copy to prevent mutation of the module-level constant.
     """
-    return SELECTOR_SCHEMAS["target"]
+    return copy.deepcopy(SELECTOR_SCHEMAS["target"])

--- a/src/hamster_mcp/mcp/_core/selector_schemas.py
+++ b/src/hamster_mcp/mcp/_core/selector_schemas.py
@@ -1,0 +1,343 @@
+"""JSON Schema definitions for Home Assistant selectors.
+
+Provides structured schema information for HA selector types, enabling LLMs
+to navigate type hierarchies on-demand via discriminator-style annotations.
+
+The selector system uses a single-key object pattern as its discriminator:
+{"selector": {"number": {...}}} - the key "number" identifies the type.
+
+This module provides:
+- SELECTOR_SCHEMAS: JSON Schema definitions per selector type
+- SELECTOR_TYPES: List of all known selector types for x-selector-types annotation
+- get_selector_schema(): Retrieve schema for a specific selector type
+- get_selector_list_schema(): Get schema listing all available types
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _string_or_array(description: str) -> dict[str, Any]:
+    """Create a schema for a value that can be string or array of strings."""
+    return {
+        "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}},
+        ],
+        "description": description,
+    }
+
+
+# JSON Schema definitions for each selector type.
+# Keys match HA's selector type names exactly.
+SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
+    "action": {
+        "type": "array",
+        "x-selector-type": "action",
+        "description": "An automation action sequence (list of action objects)",
+        "items": {"type": "object"},
+    },
+    "addon": {
+        "type": "string",
+        "x-selector-type": "addon",
+        "description": "Home Assistant add-on slug",
+    },
+    "area": {
+        "type": "string",
+        "x-selector-type": "area",
+        "description": "Area ID (e.g., 'living_room')",
+    },
+    "assist_pipeline": {
+        "type": "string",
+        "x-selector-type": "assist_pipeline",
+        "description": "Assist pipeline ID",
+    },
+    "attribute": {
+        "type": "string",
+        "x-selector-type": "attribute",
+        "description": "Entity attribute name",
+    },
+    "backup_location": {
+        "type": "string",
+        "x-selector-type": "backup_location",
+        "description": "Backup location identifier",
+    },
+    "boolean": {
+        "type": "boolean",
+        "x-selector-type": "boolean",
+        "description": "Boolean value: true or false",
+    },
+    "color_rgb": {
+        "type": "array",
+        "x-selector-type": "color_rgb",
+        "description": "RGB color as [R, G, B], each 0-255",
+        "items": {"type": "integer", "minimum": 0, "maximum": 255},
+        "minItems": 3,
+        "maxItems": 3,
+    },
+    "color_temp": {
+        "type": "integer",
+        "x-selector-type": "color_temp",
+        "description": "Color temperature in mireds (lower=cooler, higher=warmer)",
+    },
+    "condition": {
+        "type": "object",
+        "x-selector-type": "condition",
+        "description": "An automation condition object",
+    },
+    "config_entry": {
+        "type": "string",
+        "x-selector-type": "config_entry",
+        "description": "Config entry ID",
+    },
+    "constant": {
+        "x-selector-type": "constant",
+        "description": "A fixed constant value defined by the service",
+    },
+    "conversation_agent": {
+        "type": "string",
+        "x-selector-type": "conversation_agent",
+        "description": "Conversation agent ID",
+    },
+    "country": {
+        "type": "string",
+        "x-selector-type": "country",
+        "description": "ISO 3166-1 alpha-2 country code (e.g., 'US')",
+        "pattern": "^[A-Z]{2}$",
+    },
+    "date": {
+        "type": "string",
+        "x-selector-type": "date",
+        "description": "Date in ISO format",
+        "format": "date",
+        "examples": ["2024-01-15"],
+    },
+    "datetime": {
+        "type": "string",
+        "x-selector-type": "datetime",
+        "description": "Date and time in ISO format",
+        "format": "date-time",
+        "examples": ["2024-01-15T14:30:00"],
+    },
+    "device": {
+        "type": "string",
+        "x-selector-type": "device",
+        "description": "Device ID",
+    },
+    "duration": {
+        "type": "object",
+        "x-selector-type": "duration",
+        "description": "Time duration with optional components",
+        "properties": {
+            "days": {"type": "number", "minimum": 0},
+            "hours": {"type": "number", "minimum": 0},
+            "minutes": {"type": "number", "minimum": 0},
+            "seconds": {"type": "number", "minimum": 0},
+            "milliseconds": {"type": "number", "minimum": 0},
+        },
+        "additionalProperties": False,
+        "examples": [{"hours": 1, "minutes": 30}],
+    },
+    "entity": {
+        "type": "string",
+        "x-selector-type": "entity",
+        "description": "Entity ID (e.g., 'light.living_room')",
+        "pattern": "^[a-z_]+\\.[a-z0-9_]+$",
+    },
+    "file": {
+        "type": "string",
+        "x-selector-type": "file",
+        "description": "File path or file content",
+    },
+    "floor": {
+        "type": "string",
+        "x-selector-type": "floor",
+        "description": "Floor ID",
+    },
+    "icon": {
+        "type": "string",
+        "x-selector-type": "icon",
+        "description": "Material Design Icon name (e.g., 'mdi:lightbulb')",
+        "pattern": "^mdi:[a-z0-9-]+$",
+    },
+    "label": {
+        "type": "string",
+        "x-selector-type": "label",
+        "description": "Label ID",
+    },
+    "language": {
+        "type": "string",
+        "x-selector-type": "language",
+        "description": "Language code (e.g., 'en', 'de', 'fr')",
+    },
+    "location": {
+        "type": "object",
+        "x-selector-type": "location",
+        "description": "Geographic location with coordinates",
+        "properties": {
+            "latitude": {"type": "number", "minimum": -90, "maximum": 90},
+            "longitude": {"type": "number", "minimum": -180, "maximum": 180},
+            "radius": {"type": "number", "minimum": 0},
+        },
+        "required": ["latitude", "longitude"],
+        "examples": [{"latitude": 40.7128, "longitude": -74.006}],
+    },
+    "media": {
+        "type": "object",
+        "x-selector-type": "media",
+        "description": "Media content specification",
+        "properties": {
+            "entity_id": {"type": "string"},
+            "media_content_id": {"type": "string"},
+            "media_content_type": {"type": "string"},
+        },
+    },
+    "navigation": {
+        "type": "string",
+        "x-selector-type": "navigation",
+        "description": "Navigation path within Home Assistant",
+    },
+    "number": {
+        "type": "number",
+        "x-selector-type": "number",
+        "description": "Numeric value (may have min/max/step constraints per service)",
+    },
+    "object": {
+        "type": "object",
+        "x-selector-type": "object",
+        "description": "Arbitrary JSON object",
+    },
+    "qr_code": {
+        "type": "string",
+        "x-selector-type": "qr_code",
+        "description": "QR code data",
+    },
+    "schedule": {
+        "type": "object",
+        "x-selector-type": "schedule",
+        "description": "Schedule definition object",
+    },
+    "select": {
+        "type": "string",
+        "x-selector-type": "select",
+        "description": (
+            "One of a fixed set of string options (see service for valid values)"
+        ),
+    },
+    "selector": {
+        "type": "object",
+        "x-selector-type": "selector",
+        "description": "A selector definition object (meta-type)",
+    },
+    "state": {
+        "type": "string",
+        "x-selector-type": "state",
+        "description": "Entity state value",
+    },
+    "statistic": {
+        "type": "string",
+        "x-selector-type": "statistic",
+        "description": "Statistic ID for long-term statistics",
+    },
+    "stt": {
+        "type": "string",
+        "x-selector-type": "stt",
+        "description": "Speech-to-text engine ID",
+    },
+    "target": {
+        "type": "object",
+        "x-selector-type": "target",
+        "x-target-keys": ["entity_id", "device_id", "area_id", "floor_id", "label_id"],
+        "description": "Service target specification",
+        "properties": {
+            "entity_id": _string_or_array("Entity ID(s) to target"),
+            "device_id": _string_or_array("Device ID(s) to target"),
+            "area_id": _string_or_array("Area ID(s) to target"),
+            "floor_id": _string_or_array("Floor ID(s) to target"),
+            "label_id": _string_or_array("Label ID(s) to target"),
+        },
+        "additionalProperties": False,
+    },
+    "template": {
+        "type": "string",
+        "x-selector-type": "template",
+        "description": "Jinja2 template string (rendered at execution time)",
+        "examples": ["{{ states('sensor.temperature') | float > 25 }}"],
+    },
+    "text": {
+        "type": "string",
+        "x-selector-type": "text",
+        "description": "Text string (may have multiline or regex constraints)",
+    },
+    "theme": {
+        "type": "string",
+        "x-selector-type": "theme",
+        "description": "Theme name",
+    },
+    "time": {
+        "type": "string",
+        "x-selector-type": "time",
+        "description": "Time in HH:MM:SS format",
+        "pattern": "^\\d{2}:\\d{2}(:\\d{2})?$",
+        "examples": ["14:30:00"],
+    },
+    "trigger": {
+        "type": "object",
+        "x-selector-type": "trigger",
+        "description": "An automation trigger definition",
+    },
+    "tts": {
+        "type": "string",
+        "x-selector-type": "tts",
+        "description": "Text-to-speech engine ID",
+    },
+    "ui_action": {
+        "type": "object",
+        "x-selector-type": "ui_action",
+        "description": "UI action definition",
+    },
+    "ui_color": {
+        "type": "string",
+        "x-selector-type": "ui_color",
+        "description": "UI color value",
+    },
+}
+
+# Sorted list of all selector types for discovery
+SELECTOR_TYPES: list[str] = sorted(SELECTOR_SCHEMAS.keys())
+
+
+def get_selector_schema(selector_type: str) -> dict[str, Any] | None:
+    """Get the JSON Schema for a specific selector type.
+
+    Args:
+        selector_type: The selector type name (e.g., 'duration', 'entity')
+
+    Returns:
+        JSON Schema dict for the selector, or None if unknown type.
+    """
+    return SELECTOR_SCHEMAS.get(selector_type)
+
+
+def get_selector_list_schema() -> dict[str, Any]:
+    """Get a schema listing all available selector types.
+
+    Returns:
+        Schema with x-selector-types annotation for type discovery.
+    """
+    return {
+        "x-selector-types": SELECTOR_TYPES,
+        "description": (
+            "Home Assistant selector types. Use schema('selector/<type>') "
+            "to get the full JSON Schema for a specific type."
+        ),
+    }
+
+
+def get_target_schema() -> dict[str, Any]:
+    """Get the JSON Schema for the target specification.
+
+    This is the discriminated union for service targeting.
+    """
+    return SELECTOR_SCHEMAS["target"]

--- a/src/hamster_mcp/mcp/_tests/test_groups.py
+++ b/src/hamster_mcp/mcp/_tests/test_groups.py
@@ -310,6 +310,41 @@ class TestServicesGroupExplain:
         group = ServicesGroup.create({"light": {"turn_on": {"description": "Turn on"}}})
         assert group.explain("light") is None
 
+    def test_explain_includes_schema_references(self) -> None:
+        """explain() includes schema references for selectors used."""
+        group = ServicesGroup.create(
+            {
+                "light": {
+                    "turn_on": {
+                        "description": "Turn on the light",
+                        "target": {"entity": {"domain": "light"}},
+                        "fields": {
+                            "brightness": {
+                                "selector": {"number": {}},
+                                "description": "Brightness level",
+                            },
+                            "transition": {
+                                "selector": {"number": {}},
+                            },
+                            "effect": {
+                                "selector": {"text": {}},
+                            },
+                        },
+                    }
+                }
+            }
+        )
+        result = group.explain("light.turn_on")
+        assert result is not None
+        # Check for schema references section
+        assert "Schema References" in result
+        assert 'schema("light.turn_on")' in result
+        # Check for selector type references
+        assert 'schema("selector/number")' in result
+        assert 'schema("selector/text")' in result
+        # Check for target schema hint
+        assert 'schema("selector/target")' in result
+
 
 class TestServicesGroupSchema:
     """Tests for ServicesGroup.schema()."""
@@ -355,6 +390,64 @@ class TestServicesGroupSchema:
         result = group.schema("selector/unknown_type")
         assert result is not None
         assert "Unknown selector type" in result
+
+    def test_schema_selector_list(self) -> None:
+        """schema("selector") returns list of all selector types."""
+        group = ServicesGroup.create({})
+        result = group.schema("selector")
+        assert result is not None
+        assert "x-selector-types" in result
+        assert "duration" in result
+        assert "entity" in result
+        assert "target" in result
+
+    def test_schema_selector_json_block(self) -> None:
+        """schema() returns JSON Schema in code block."""
+        group = ServicesGroup.create({})
+        result = group.schema("selector/duration")
+        assert result is not None
+        assert "```json" in result
+        assert '"x-selector-type": "duration"' in result
+        assert '"type": "object"' in result
+
+    def test_schema_target_has_target_keys(self) -> None:
+        """schema("selector/target") includes x-target-keys annotation."""
+        group = ServicesGroup.create({})
+        result = group.schema("selector/target")
+        assert result is not None
+        assert "x-target-keys" in result
+        assert "entity_id" in result
+        assert "device_id" in result
+        assert "area_id" in result
+
+    def test_schema_service_returns_json_schema(self) -> None:
+        """schema() with service path returns JSON Schema for fields."""
+        group = ServicesGroup.create(
+            {
+                "light": {
+                    "turn_on": {
+                        "fields": {
+                            "brightness": {
+                                "required": True,
+                                "selector": {"number": {}},
+                                "description": "Brightness level",
+                            },
+                            "transition": {
+                                "selector": {"number": {}},
+                                "description": "Transition time",
+                            },
+                        }
+                    }
+                }
+            }
+        )
+        result = group.schema("light.turn_on")
+        assert result is not None
+        assert "```json" in result
+        assert '"type": "object"' in result
+        assert '"properties"' in result
+        assert '"brightness"' in result
+        assert '"required"' in result
 
 
 class TestServicesGroupHasCommand:


### PR DESCRIPTION
## Summary

Adapt onshape-mcp's discriminator annotation pattern for HA's type structures, enabling LLMs to navigate selector and target hierarchies on-demand.

- Add JSON Schema definitions for all 40 HA selector types
- Update `schema()` to return hybrid JSON Schema + Markdown output
- Add `x-selector-types` annotation for selector type discovery
- Add `x-target-keys` annotation for target field discovery  
- Update `explain()` to include schema references for drill-down

## Example Usage

**List all selector types:**
```
schema("selector")
```
Returns `x-selector-types` array with all 40 types.

**Get JSON Schema for a selector:**
```
schema("selector/duration")
```
Returns:
```json
{
  "type": "object",
  "x-selector-type": "duration",
  "properties": {
    "hours": {"type": "number"},
    "minutes": {"type": "number"},
    ...
  }
}
```

**Get service parameters schema:**
```
schema("light.turn_on")
```
Returns JSON Schema with field types and `x-selector-type` annotations.

## Related Issues

- Closes #49
- Created #137 for follow-up entity registry type exploration