### PR TITLE
Fix Home Assistant authentication docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ wherever your HA instance is.
 Some AI tools will prompt you to log in through Home Assistant
 automatically — just follow the login screen when it appears. Others
 need a static token: create a
-[Long-Lived Access Token](https://www.home-assistant.io/docs/authentication/#your-account-profile)
+[Long-Lived Access Token](https://www.home-assistant.io/docs/authentication/#managing-account-access)
 in your HA profile (under Security) and provide it as a Bearer token in
 your AI tool's configuration. Treat this token like a password — don't
 share it or commit it to version control.


### PR DESCRIPTION
## Summary

- Update the Home Assistant authentication docs link to the current `#managing-account-access` anchor.

## Verification

- `pre-commit run --all-files`
