### PR TITLE
Split Mergify queue from GitHub branch protection

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
+    inputs:
+      debug:
+        description: "Enable debug logging"
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -12,29 +18,18 @@ jobs:
     name: Renovate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
-          app-id: ${{ vars.RENOVATE_APP_ID }}
+          client-id: ${{ vars.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-        with:
-          install: false
-
-      - id: mise-path
-        run: |
-          bin=$(which mise)
-          if [[ -z "$bin" ]]; then
-            echo "::error::mise binary not found in PATH"
-            exit 1
-          fi
-          echo "bin=$bin" >> "$GITHUB_OUTPUT"
-
-      - uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d # v46.1.8
+      - uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
         with:
           token: ${{ steps.app-token.outputs.token }}
-          docker-volumes: /tmp:/tmp;${{ steps.mise-path.outputs.bin }}:/usr/local/bin/mise
+          docker-user: 12021:0
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
-          RENOVATE_ALLOWED_COMMANDS: '["^mise lock [A-Za-z0-9_./:-]+$"]'
+          RENOVATE_ALLOWED_COMMANDS: '[".*"]'
+          RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'
+          LOG_LEVEL: ${{ inputs.debug && 'debug' || 'info' }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,10 @@
 queue_rules:
   - name: default
-    autoqueue: true
-    branch_protection_injection_mode: merge
+    branch_protection_injection_mode: queue
     queue_conditions:
       - label = enqueue
       - base = main
-      - "#approved-reviews-by >= 1"
+      - -draft
     merge_method: merge
     checks_timeout: 90 min
     max_checks_retries: 2
@@ -14,6 +13,15 @@ merge_queue:
   max_parallel_checks: 1
 
 pull_request_rules:
+  - name: Queue enqueue PRs
+    conditions:
+      - base = main
+      - label = enqueue
+      - -draft
+    actions:
+      queue:
+        name: default
+
   - name: Automatically approve Renovate PRs
     conditions:
       - author = altendky-renovate[bot]
@@ -28,3 +36,6 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
+
+merge_protections_settings:
+  reporting_method: deployments


### PR DESCRIPTION
Closes #150.

Adopts the Mergify/GitHub branch-protection split proven in `altendky/onshape-mcp` (onshape-mcp#400, onshape-mcp#403). The repository ruleset already requires only the `all` aggregate CI check and one approval with merge-only, so no GitHub-side changes are needed; this PR aligns `.mergify.yml` and the self-hosted Renovate workflow.

## .mergify.yml

- `branch_protection_injection_mode`: `merge` -> `queue`.
- Drop `autoqueue: true` in favor of an explicit `pull_request_rules` queue action.
- Drop `#approved-reviews-by >= 1` from queue conditions; GitHub now owns required approvals.
- Add `-draft` to queue conditions and the new PR rule.
- Add `merge_protections_settings.reporting_method: deployments` so Mergify reports via deployments instead of the legacy `check-runs` default (`Mergify Merge Protections` is not a required GitHub status check).
- Preserve the existing auto-approve rules for `altendky-renovate[bot]` and `altendky-release[bot]` post-release branches.

## .github/workflows/renovate.yml

Applies the validated self-hosted Renovate pattern from onshape-mcp#480, onshape-mcp#482, onshape-mcp#483:

- `actions/create-github-app-token` pinned to `bcd2ba49` (v3); switch from deprecated `app-id` to `client-id: ${{ vars.RENOVATE_CLIENT_ID }}`.
- `renovatebot/github-action` pinned to `8217b3fc` (v46.1.15).
- Remove the host `jdx/mise-action` setup and the `/usr/local/bin/mise` bind-mount. In the Renovate image, `/usr/local/bin` points to `/opt/containerbase/bin`, so the mount blocked Containerbase `install-tool mise` (EACCES). Let Containerbase install `mise` inside the container instead.
- `docker-user: 12021:0`.
- `RENOVATE_ALLOWED_COMMANDS: '[".*"]'` plus `RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'` to clear the `mise lock` dashboard warning.
- Add a `workflow_dispatch` `debug` input wired to `LOG_LEVEL`.

## Not changed

- `renovate.json5` already sets `rebaseWhen: "conflicted"`.
- GitHub ruleset `default` (id 14082824) already requires only `all`, one approval, merge-only, and is not strict; no ruleset edits required.

## Validation

- `.mergify.yml` and `.github/workflows/renovate.yml` parsed with `yaml.safe_load`.
- Pre-commit hooks passed locally including `Validate Mergify configuration` and `Lint GitHub Actions workflow files`.
- Post-merge: applying `enqueue` to an approved PR should trigger a single Mergify queue CI run (`max_parallel_checks: 1`) with no speculative reruns; next Renovate run should show no `mise` `allowedUnsafeExecutions` warning on the Dependency Dashboard.