### PR TITLE
Harden internal WebSocket command execution against HA API changes

### DIFF
--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -913,6 +913,27 @@ class TestExecuteHassCommandUnknownUser:
         handler.assert_not_called()
 
 
+async def test_execute_hass_command_empty_user_id_returns_error(
+    effect_handler: HamsterEffectHandler,
+    mock_hass: MagicMock,
+) -> None:
+    """An empty string user_id is a provided but unknown user."""
+    mock_hass.auth.async_get_user.return_value = None
+    handler = MagicMock()
+    mock_hass.data = {"websocket_api": {"get_states": (handler, False)}}
+
+    result = await effect_handler.execute_hass_command(
+        command_type="get_states",
+        params={},
+        user_id="",
+    )
+
+    assert result.success is False
+    assert "Unknown user" in (result.error or "")
+    mock_hass.auth.async_get_user.assert_called_once_with("")
+    handler.assert_not_called()
+
+
 class TestExecuteHassCommandRegistryShape:
     """Tests defensive handling of unexpected websocket_api registry shapes."""
 

--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -5,12 +5,16 @@ Tests for InternalConnection and execute_hass_command() in the effect handler.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import voluptuous as vol
 
 from hamster_mcp.component.http import HamsterEffectHandler, InternalConnection
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(autouse=True)
@@ -736,7 +740,12 @@ class TestExecuteHassCommandParams:
     async def test_params_passed_to_handler(
         self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
     ) -> None:
-        """Parameters are passed to the handler in the message."""
+        """Parameters are passed to the handler in the message.
+
+        Uses a schema that accepts extra params --- with ``schema=False``,
+        extra params are now rejected to match HA's WebSocket connection
+        behavior (see ``test_schema_false_rejects_extra_params``).
+        """
         captured_msg = None
 
         def capture_handler(
@@ -746,7 +755,15 @@ class TestExecuteHassCommandParams:
             captured_msg = msg
             conn.send_result(msg["id"], None)  # type: ignore[arg-type]
 
-        mock_hass.data = {"websocket_api": {"test_command": (capture_handler, False)}}
+        schema = vol.Schema(
+            {
+                vol.Required("id"): int,
+                vol.Required("type"): str,
+                vol.Required("entity_id"): str,
+                vol.Required("extra"): int,
+            }
+        )
+        mock_hass.data = {"websocket_api": {"test_command": (capture_handler, schema)}}
 
         await effect_handler.execute_hass_command(
             command_type="test_command",
@@ -759,3 +776,368 @@ class TestExecuteHassCommandParams:
         assert captured_msg["entity_id"] == "light.living_room"
         assert captured_msg["extra"] == 123
         assert "id" in captured_msg  # Message ID is added
+
+
+class TestExecuteHassCommandSchemaFalseExtraKeys:
+    """Tests that ``schema is False`` rejects extra parameters.
+
+    Mirrors HA's ``ActiveConnection.async_handle`` behavior of raising
+    ``vol.Invalid("extra keys not allowed")`` when a no-schema command
+    receives anything beyond ``id`` and ``type``.
+    """
+
+    async def test_schema_false_rejects_extra_params(
+        self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
+    ) -> None:
+        """schema=False with extra params returns a validation error."""
+        handler = MagicMock()
+        mock_hass.data = {"websocket_api": {"get_states": (handler, False)}}
+
+        result = await effect_handler.execute_hass_command(
+            command_type="get_states",
+            params={"extra": 123},
+            user_id=None,
+        )
+
+        assert result.success is False
+        assert "extra keys not allowed" in (result.error or "")
+        handler.assert_not_called()
+
+    async def test_schema_false_no_params_succeeds(
+        self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
+    ) -> None:
+        """schema=False with no extra params executes normally."""
+
+        def sync_handler(
+            hass: MagicMock, conn: InternalConnection, msg: dict[str, object]
+        ) -> None:
+            conn.send_result(msg["id"], {"states": []})  # type: ignore[arg-type]
+
+        mock_hass.data = {"websocket_api": {"get_states": (sync_handler, False)}}
+
+        result = await effect_handler.execute_hass_command(
+            command_type="get_states",
+            params={},
+            user_id=None,
+        )
+
+        assert result.success is True
+        assert result.data == {"states": []}
+
+
+class TestExecuteHassCommandUnknownUser:
+    """Tests rejection of unknown / invalid user_id."""
+
+    async def test_unknown_user_id_returns_error(
+        self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
+    ) -> None:
+        """An unresolvable user_id fails before the handler runs."""
+        mock_hass.auth.async_get_user.return_value = None
+        handler = MagicMock()
+        mock_hass.data = {"websocket_api": {"get_states": (handler, False)}}
+
+        result = await effect_handler.execute_hass_command(
+            command_type="get_states",
+            params={},
+            user_id="deleted-user",
+        )
+
+        assert result.success is False
+        assert "Unknown user" in (result.error or "")
+        # Handler must not have executed --- the invalid user_id must not
+        # silently fall through as anonymous.
+        handler.assert_not_called()
+
+
+class TestExecuteHassCommandRegistryShape:
+    """Tests defensive handling of unexpected websocket_api registry shapes."""
+
+    async def test_non_tuple_registry_entry_returns_error(
+        self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
+    ) -> None:
+        """A non-tuple entry surfaces a clean error, not a ValueError."""
+        mock_hass.data = {"websocket_api": {"get_states": "not-a-tuple"}}
+
+        result = await effect_handler.execute_hass_command(
+            command_type="get_states",
+            params={},
+            user_id=None,
+        )
+
+        assert result.success is False
+        assert "Unsupported websocket_api registry entry" in (result.error or "")
+
+    async def test_wrong_arity_registry_entry_returns_error(
+        self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
+    ) -> None:
+        """A tuple of wrong arity surfaces a clean error."""
+        mock_hass.data = {
+            "websocket_api": {"get_states": (MagicMock(), False, "extra")}
+        }
+
+        result = await effect_handler.execute_hass_command(
+            command_type="get_states",
+            params={},
+            user_id=None,
+        )
+
+        assert result.success is False
+        assert "Unsupported websocket_api registry entry" in (result.error or "")
+
+    async def test_non_callable_handler_returns_error(
+        self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
+    ) -> None:
+        """A non-callable handler element surfaces a clean error."""
+        mock_hass.data = {"websocket_api": {"get_states": ("not-callable", False)}}
+
+        result = await effect_handler.execute_hass_command(
+            command_type="get_states",
+            params={},
+            user_id=None,
+        )
+
+        assert result.success is False
+        assert "Unsupported websocket_api registry entry" in (result.error or "")
+
+
+class TestInternalConnectionContract:
+    """Tests that InternalConnection honors HA's ActiveConnection contract."""
+
+    def test_set_supported_features_updates_state(self) -> None:
+        """set_supported_features updates supported_features and can_coalesce."""
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        assert conn.supported_features == {}
+        assert conn.can_coalesce is False
+
+        conn.set_supported_features({"coalesce_messages": 1.0})
+
+        assert conn.supported_features == {"coalesce_messages": 1.0}
+        assert conn.can_coalesce is True
+
+    def test_set_supported_features_without_coalesce(self) -> None:
+        """can_coalesce stays False when coalesce_messages is not advertised."""
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        conn.set_supported_features({"other_feature": 2.0})
+
+        assert conn.supported_features == {"other_feature": 2.0}
+        assert conn.can_coalesce is False
+
+    def test_connection_contract_attributes(self) -> None:
+        """InternalConnection exposes the lifecycle attributes HA expects."""
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        # These attributes exist on HA's ActiveConnection; handlers may
+        # touch them even though the internal path does not use them.
+        assert conn.subscriptions == {}
+        assert conn.supported_features == {}
+        assert conn.can_coalesce is False
+        assert conn.last_id == 0
+        assert conn.refresh_token_id is None
+
+
+class TestInternalConnectionSerialization:
+    """Tests for HA-extension serialization through send_result."""
+
+    def test_send_result_serializes_set(self) -> None:
+        """send_result converts a set in the result to a list."""
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        conn.send_result(1, {"items": {"a", "b", "c"}})
+
+        assert conn.result is not None
+        assert isinstance(conn.result, dict)
+        items = conn.result["items"]
+        assert isinstance(items, list)
+        assert sorted(items) == ["a", "b", "c"]
+
+    def test_send_result_serializes_tuple(self) -> None:
+        """send_result converts a tuple in the result to a list."""
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        conn.send_result(1, {"items": ("a", "b")})
+
+        assert conn.result == {"items": ["a", "b"]}
+
+    def test_send_result_serializes_datetime(self) -> None:
+        """send_result converts datetime objects to ISO format strings."""
+        import datetime
+
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        ts = datetime.datetime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.UTC)
+        conn.send_result(1, {"when": ts})
+
+        assert conn.result is not None
+        assert isinstance(conn.result, dict)
+        when = conn.result["when"]
+        # orjson and our HA-style default may both stringify datetimes;
+        # the contract is "JSON-safe string", not exact format.
+        assert isinstance(when, str)
+        assert when.startswith("2025-01-02")
+
+    def test_send_result_serializes_path(self) -> None:
+        """send_result converts pathlib.Path objects to posix strings.
+
+        Matches HA's ``json_encoder_default``, which uses
+        ``isinstance(obj, Path)``.
+        """
+        from pathlib import Path
+
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        conn.send_result(1, {"path": Path("/etc/hass")})
+
+        assert conn.result == {"path": "/etc/hass"}
+
+    def test_send_result_uses_json_fragment_attribute(self) -> None:
+        """send_result inlines objects exposing a json_fragment attribute."""
+        import orjson
+
+        class FragmentHolder:
+            json_fragment = orjson.Fragment(b'{"hello": "world"}')
+
+        hass = MagicMock()
+        conn = InternalConnection(hass, None)
+
+        conn.send_result(1, {"payload": FragmentHolder()})
+
+        assert conn.result == {"payload": {"hello": "world"}}
+
+
+@pytest.fixture
+def hass_with_websocket_registry(hass: HomeAssistant) -> HomeAssistant:
+    """Populate ``hass.data["websocket_api"]`` with HA's real command registry.
+
+    Bypasses ``async_setup`` (which requires ``hass.http`` registration) by
+    directly running ``async_register_commands`` against an in-memory dict.
+    This exercises the real handler+schema entries shipped by HA, not
+    hand-rolled tuples.
+    """
+    from homeassistant.components.websocket_api import commands, const
+
+    registry: dict[str, object] = {}
+    hass.data[const.DOMAIN] = registry
+
+    def register(
+        h: HomeAssistant,
+        command_or_handler: object,
+        handler: object = None,
+        schema: object = None,
+    ) -> None:
+        if handler is None:
+            handler = command_or_handler
+            command = handler._ws_command  # type: ignore[attr-defined]
+            schema = handler._ws_schema  # type: ignore[attr-defined]
+        else:
+            command = command_or_handler
+        registry[command] = (handler, schema)
+
+    commands.async_register_commands(hass, register)
+    return hass
+
+
+@pytest.fixture
+async def admin_user_id(hass: HomeAssistant) -> str:
+    """Create an admin user and return its id.
+
+    Many real HA websocket handlers (e.g. get_states) inspect
+    ``connection.user.is_admin``, so we need a real user --- not None ---
+    to drive them.
+    """
+    admin_group = await hass.auth.async_get_group("system-admin")
+    assert admin_group is not None, "system-admin group must be available in test hass"
+    user = await hass.auth.async_create_user("admin", group_ids=[admin_group.id])
+    return user.id
+
+
+class TestRealHARegistry:
+    """Integration tests against HA's real WebSocket command registry.
+
+    These tests use the actual handlers and schemas shipped by HA rather
+    than hand-rolled mocks, so they detect drift in HA's private contract.
+    """
+
+    async def test_get_states_success(
+        self,
+        hass_with_websocket_registry: HomeAssistant,
+        admin_user_id: str,
+    ) -> None:
+        """get_states succeeds against the real handler and returns a list."""
+        handler = HamsterEffectHandler(hass_with_websocket_registry)
+
+        result = await handler.execute_hass_command(
+            command_type="get_states",
+            params={},
+            user_id=admin_user_id,
+        )
+
+        assert result.success is True
+        # get_states returns a list of state dicts (possibly empty in a fresh
+        # test hass).
+        assert isinstance(result.data, list)
+
+    async def test_get_states_rejects_extra_params(
+        self,
+        hass_with_websocket_registry: HomeAssistant,
+        admin_user_id: str,
+    ) -> None:
+        """get_states (schema=False) rejects extra params, matching HA."""
+        handler = HamsterEffectHandler(hass_with_websocket_registry)
+
+        result = await handler.execute_hass_command(
+            command_type="get_states",
+            params={"entity_id": "light.living_room"},
+            user_id=admin_user_id,
+        )
+
+        assert result.success is False
+        assert "extra keys not allowed" in (result.error or "")
+
+    async def test_supported_features_filtered(
+        self, hass_with_websocket_registry: HomeAssistant
+    ) -> None:
+        """supported_features is filtered out at the HassGroup layer.
+
+        Direct invocation via ``execute_hass_command`` would still try to
+        call ``set_supported_features`` on the InternalConnection (which we
+        now support), but the user-facing surface (HassGroup.has_command)
+        rejects it so it cannot be reached from MCP.
+        """
+        from hamster_mcp.mcp._core.hass_group import (
+            HassGroup,
+            discover_commands,
+        )
+
+        registry = hass_with_websocket_registry.data["websocket_api"]
+        commands = discover_commands(registry)
+        group = HassGroup.create(commands)
+
+        assert group.has_command("supported_features") is False
+        assert group.has_command("render_template") is False
+        assert group.has_command("fire_event") is False
+        # Sanity: a normal command is still available.
+        assert group.has_command("get_states") is True
+
+    async def test_unknown_user_rejected_against_real_registry(
+        self, hass_with_websocket_registry: HomeAssistant
+    ) -> None:
+        """An invalid user_id is rejected before the real handler runs."""
+        handler = HamsterEffectHandler(hass_with_websocket_registry)
+
+        result = await handler.execute_hass_command(
+            command_type="get_states",
+            params={},
+            user_id="does-not-exist",
+        )
+
+        assert result.success is False
+        assert "Unknown user" in (result.error or "")

--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -825,6 +825,70 @@ class TestExecuteHassCommandSchemaFalseExtraKeys:
         assert result.data == {"states": []}
 
 
+@pytest.mark.parametrize(
+    ("params", "expected_keys"),
+    [
+        ({"id": 99}, "['id']"),
+        ({"type": "get_states"}, "['type']"),
+        ({"id": 99, "type": "anything"}, "['id', 'type']"),
+    ],
+)
+async def test_execute_hass_command_schema_false_rejects_reserved_params(
+    effect_handler: HamsterEffectHandler,
+    mock_hass: MagicMock,
+    params: dict[str, object],
+    expected_keys: str,
+) -> None:
+    """schema=False treats reserved envelope fields as invalid params."""
+    handler = MagicMock()
+    mock_hass.data = {"websocket_api": {"get_states": (handler, False)}}
+
+    result = await effect_handler.execute_hass_command(
+        command_type="get_states",
+        params=params,
+        user_id=None,
+    )
+
+    assert result.success is False
+    assert f"reserved keys not allowed: {expected_keys}" in (result.error or "")
+    handler.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("params", "expected_keys"),
+    [
+        ({"entity_id": "light.living_room", "id": 99}, "['id']"),
+        ({"entity_id": "light.living_room", "type": "get_entity"}, "['type']"),
+    ],
+)
+async def test_execute_hass_command_schema_rejects_reserved_params(
+    effect_handler: HamsterEffectHandler,
+    mock_hass: MagicMock,
+    params: dict[str, object],
+    expected_keys: str,
+) -> None:
+    """Schema-backed commands also reject caller-supplied envelope fields."""
+    handler = MagicMock()
+    schema = vol.Schema(
+        {
+            vol.Required("id"): int,
+            vol.Required("type"): str,
+            vol.Required("entity_id"): str,
+        }
+    )
+    mock_hass.data = {"websocket_api": {"get_entity": (handler, schema)}}
+
+    result = await effect_handler.execute_hass_command(
+        command_type="get_entity",
+        params=params,
+        user_id=None,
+    )
+
+    assert result.success is False
+    assert f"reserved keys not allowed: {expected_keys}" in (result.error or "")
+    handler.assert_not_called()
+
+
 class TestExecuteHassCommandUnknownUser:
     """Tests rejection of unknown / invalid user_id."""
 

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -23,6 +23,7 @@ from homeassistant.exceptions import (
 )
 import voluptuous as vol
 
+from hamster_mcp.mcp._core.hass_group import _unpack_handler_entry
 from hamster_mcp.mcp._core.registry_enrichment import (
     AreaInfo,
     DeviceInfo,
@@ -50,8 +51,11 @@ _LOGGER = logging.getLogger(__name__)
 def _orjson_default(obj: object) -> object:
     """Convert non-serializable objects for orjson.
 
-    Handles objects with as_dict() method (e.g., Context) by converting
-    them to dictionaries.
+    Mirrors Home Assistant's ``json_encoder_default``
+    (``homeassistant.helpers.json``) so handler results containing HA
+    extension types --- sets, tuples, ``Path``, ``datetime``,
+    ``json_fragment``, and objects with ``as_dict()`` --- round-trip the
+    same way HA's real WebSocket connection would serialize them.
 
     Args:
         obj: Object that orjson doesn't know how to serialize
@@ -62,9 +66,21 @@ def _orjson_default(obj: object) -> object:
     Raises:
         TypeError: If object cannot be converted
     """
+    import datetime
+    from pathlib import Path
+
+    json_fragment = getattr(obj, "json_fragment", None)
+    if json_fragment is not None:
+        return json_fragment
+    if isinstance(obj, (set, tuple)):
+        return list(obj)
     as_dict = getattr(obj, "as_dict", None)
     if callable(as_dict):
         return as_dict()
+    if isinstance(obj, Path):
+        return obj.as_posix()
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
     raise TypeError(f"Type is not JSON serializable: {type(obj).__name__}")
 
 
@@ -78,14 +94,36 @@ class InternalConnection:
 
     hass: HomeAssistant
     user: User | None
-    # Required by ActiveConnection interface
+    # Required by ActiveConnection interface. These are not used by the
+    # internal invocation path but are kept in sync with HA's connection
+    # contract so handlers that touch them (e.g. supported_features,
+    # last_id bookkeeping in error paths) do not raise AttributeError.
     subscriptions: dict[Hashable, Callable[[], Any]] = field(default_factory=dict)
     supported_features: dict[str, float] = field(default_factory=dict)
+    can_coalesce: bool = False
+    last_id: int = 0
+    refresh_token_id: str | None = None
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
     # Result capture
     _result_event: asyncio.Event = field(init=False, default_factory=asyncio.Event)
     result: object = field(init=False, default=None)
     error: tuple[str, str] | None = field(init=False, default=None)  # (code, message)
+
+    @callback
+    def set_supported_features(self, features: dict[str, float]) -> None:
+        """Record supported features (mirrors HA's ActiveConnection).
+
+        The internal adapter does not negotiate features with a client, so
+        this only updates the local state. The ``supported_features``
+        command itself is filtered out by HassGroup; this method exists
+        to keep the connection contract intact for any other handler that
+        might inspect or set features.
+        """
+        self.supported_features = features
+        # Mirror HA's behavior of recomputing can_coalesce. We do not
+        # import the const to avoid leaking another private dependency;
+        # the key name is stable HA public protocol.
+        self.can_coalesce = "coalesce_messages" in features
 
     def context(self, msg: dict[str, object]) -> Context:
         """Create a context for command execution.
@@ -337,13 +375,33 @@ class HamsterEffectHandler:
                 success=False, error=f"Unknown command: {command_type}"
             )
 
-        handler, schema = handler_info
+        # Guard against HA registry shape drift. The current shape is
+        # ``(handler, schema_or_False)``; bail out cleanly if that changes
+        # so we surface a clear error instead of an unpacking ValueError.
+        unpacked = _unpack_handler_entry(handler_info)
+        if unpacked is None:
+            return HassCommandResult(
+                success=False,
+                error=(
+                    f"Unsupported websocket_api registry entry for '{command_type}'"
+                ),
+            )
+        handler, schema = unpacked
 
         # Build message with required fields
         msg: dict[str, object] = {"id": 1, "type": command_type, **params}
 
         # Validate params against schema if present (schema=False means no params)
-        if schema is not False:
+        if schema is False:
+            # Mirror HA's connection.async_handle behavior: when there is
+            # no schema, only ``id`` and ``type`` are allowed.
+            if len(msg) > 2:
+                extra = sorted(set(msg) - {"id", "type"})
+                return HassCommandResult(
+                    success=False,
+                    error=f"Validation error: extra keys not allowed: {extra}",
+                )
+        else:
             try:
                 msg = schema(msg)
             except vol.Invalid as err:
@@ -351,10 +409,17 @@ class HamsterEffectHandler:
                     success=False, error=f"Validation error: {err}"
                 )
 
-        # Resolve user_id to User object for authorization checks
+        # Resolve user_id to User object for authorization checks. An unknown
+        # user_id must fail loudly --- falling through as anonymous would
+        # silently widen the trust boundary.
         user = None
         if user_id:
             user = await self._hass.auth.async_get_user(user_id)
+            if user is None:
+                return HassCommandResult(
+                    success=False,
+                    error=f"Unknown user: {user_id}",
+                )
 
         conn = InternalConnection(self._hass, user)
 

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -420,7 +420,7 @@ class HamsterEffectHandler:
         # user_id must fail loudly --- falling through as anonymous would
         # silently widen the trust boundary.
         user = None
-        if user_id:
+        if user_id is not None:
             user = await self._hass.auth.async_get_user(user_id)
             if user is None:
                 return HassCommandResult(

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -388,6 +388,13 @@ class HamsterEffectHandler:
             )
         handler, schema = unpacked
 
+        reserved_keys = sorted({"id", "type"}.intersection(params))
+        if reserved_keys:
+            return HassCommandResult(
+                success=False,
+                error=(f"Validation error: reserved keys not allowed: {reserved_keys}"),
+            )
+
         # Build message with required fields
         msg: dict[str, object] = {"id": 1, "type": command_type, **params}
 

--- a/src/hamster_mcp/mcp/_core/hass_group.py
+++ b/src/hamster_mcp/mcp/_core/hass_group.py
@@ -244,10 +244,10 @@ def _make_error(message: str) -> Done:
     )
 
 
-# Commands that produce events / subscriptions or require connection-level
-# behavior (set_supported_features, feature negotiation, side-effectful event
-# firing) that the internal adapter does not implement. These are filtered
-# regardless of name pattern.
+# Commands that produce events / subscriptions or represent connection-level
+# lifecycle behavior (feature negotiation, side-effectful event firing) rather
+# than request/response command data. These are filtered regardless of name
+# pattern.
 _EXPLICITLY_FILTERED_COMMANDS: frozenset[str] = frozenset(
     {
         # Event-producing: registers a long-lived listener and emits event

--- a/src/hamster_mcp/mcp/_core/hass_group.py
+++ b/src/hamster_mcp/mcp/_core/hass_group.py
@@ -244,21 +244,47 @@ def _make_error(message: str) -> Done:
     )
 
 
+# Commands that produce events / subscriptions or require connection-level
+# behavior (set_supported_features, feature negotiation, side-effectful event
+# firing) that the internal adapter does not implement. These are filtered
+# regardless of name pattern.
+_EXPLICITLY_FILTERED_COMMANDS: frozenset[str] = frozenset(
+    {
+        # Event-producing: registers a long-lived listener and emits event
+        # messages through send_message. The internal adapter only captures
+        # the first result and raises on subsequent event messages.
+        "render_template",
+        # Calls connection.set_supported_features for feature negotiation.
+        # This is a connection-lifecycle concern, not a request/response.
+        "supported_features",
+        # Fires an arbitrary event onto the bus. Not a read-only query, and
+        # not something we want to expose through the MCP surface.
+        "fire_event",
+    }
+)
+
+
 def _is_filtered_command(command_type: str) -> bool:
     """Check if a command should be filtered out.
 
     Filters:
-    - Commands starting with "subscribe" or "unsubscribe"
-    - Commands starting with "auth" or "auth/"
+    - Commands containing ``subscribe`` or ``unsubscribe`` anywhere in the
+      path (covers both ``subscribe_events`` and ``trigger_platforms/subscribe``).
+    - Commands starting with ``auth`` or ``auth/``.
+    - Explicitly listed event-producing or connection-lifecycle commands
+      (see ``_EXPLICITLY_FILTERED_COMMANDS``).
     """
     lower = command_type.lower()
 
-    # Filter subscription commands
-    if lower.startswith(("subscribe", "unsubscribe")):
+    # Filter subscription commands wherever the keyword appears in the path.
+    if "subscribe" in lower or "unsubscribe" in lower:
         return True
 
     # Filter auth commands
-    return lower == "auth" or lower.startswith("auth/")
+    if lower == "auth" or lower.startswith("auth/"):
+        return True
+
+    return lower in _EXPLICITLY_FILTERED_COMMANDS
 
 
 # --- HassGroup ---
@@ -518,10 +544,23 @@ def discover_commands(
     """
     commands: dict[str, CommandInfo] = {}
 
-    for command_type, (_handler, schema) in websocket_api_registry.items():
+    for command_type, entry in websocket_api_registry.items():
         # Filter out subscription and auth commands
         if _is_filtered_command(command_type):
             continue
+
+        # Guard against HA internal registry shape drift. The current shape
+        # is ``(handler, schema_or_False)`` but this is private HA state, so
+        # we defensively skip entries that no longer match.
+        unpacked = _unpack_handler_entry(entry)
+        if unpacked is None:
+            _LOGGER.debug(
+                "Skipping websocket command %s: unexpected registry shape %r",
+                command_type,
+                type(entry).__name__,
+            )
+            continue
+        _handler, schema = unpacked
 
         # Convert schema
         schema_desc = voluptuous_to_description(schema)
@@ -533,3 +572,21 @@ def discover_commands(
         )
 
     return commands
+
+
+def _unpack_handler_entry(
+    entry: object,
+) -> tuple[Any, Any] | None:
+    """Defensively unpack a ``hass.data["websocket_api"]`` registry entry.
+
+    The current HA shape is ``(handler, schema_or_False)``. Returns the
+    ``(handler, schema)`` tuple if the entry matches that shape, or ``None``
+    otherwise so callers can skip / surface a clean error instead of raising
+    ``ValueError`` from tuple unpacking.
+    """
+    if not isinstance(entry, tuple) or len(entry) != 2:
+        return None
+    handler, schema = entry
+    if not callable(handler):
+        return None
+    return handler, schema

--- a/src/hamster_mcp/mcp/_tests/test_hass_group.py
+++ b/src/hamster_mcp/mcp/_tests/test_hass_group.py
@@ -372,6 +372,108 @@ class TestCommandFiltering:
         assert _is_filtered_command("call_service") is False
         assert _is_filtered_command("config/entity_registry/list") is False
 
+    def test_subscribe_in_path_filtered(self) -> None:
+        """Commands containing 'subscribe' anywhere in the path are filtered.
+
+        HA registers commands like ``trigger_platforms/subscribe`` and
+        ``condition_platforms/subscribe`` which the previous prefix-only
+        filter missed.
+        """
+        from hamster_mcp.mcp._core.hass_group import _is_filtered_command
+
+        assert _is_filtered_command("trigger_platforms/subscribe") is True
+        assert _is_filtered_command("condition_platforms/subscribe") is True
+
+    def test_unsubscribe_in_path_filtered(self) -> None:
+        """Commands containing 'unsubscribe' anywhere are filtered."""
+        from hamster_mcp.mcp._core.hass_group import _is_filtered_command
+
+        assert _is_filtered_command("entities/unsubscribe") is True
+
+    def test_render_template_filtered(self) -> None:
+        """render_template is event-producing and must be filtered.
+
+        Although it does not contain 'subscribe' in its name,
+        ``handle_render_template`` registers a subscription and emits
+        event messages through send_message.
+        """
+        from hamster_mcp.mcp._core.hass_group import _is_filtered_command
+
+        assert _is_filtered_command("render_template") is True
+
+    def test_supported_features_filtered(self) -> None:
+        """supported_features requires set_supported_features lifecycle."""
+        from hamster_mcp.mcp._core.hass_group import _is_filtered_command
+
+        assert _is_filtered_command("supported_features") is True
+
+    def test_fire_event_filtered(self) -> None:
+        """fire_event is a side-effectful command and is filtered."""
+        from hamster_mcp.mcp._core.hass_group import _is_filtered_command
+
+        assert _is_filtered_command("fire_event") is True
+
+
+class TestUnpackHandlerEntry:
+    """Tests for the registry tuple shape guard."""
+
+    def test_valid_entry_unpacks(self) -> None:
+        """A valid (handler, schema) tuple unpacks cleanly."""
+        from hamster_mcp.mcp._core.hass_group import _unpack_handler_entry
+
+        def handler() -> None: ...  # pragma: no cover - never called
+
+        unpacked = _unpack_handler_entry((handler, False))
+        assert unpacked is not None
+        assert unpacked[0] is handler
+        assert unpacked[1] is False
+
+    def test_non_tuple_rejected(self) -> None:
+        """Non-tuple entries are rejected."""
+        from hamster_mcp.mcp._core.hass_group import _unpack_handler_entry
+
+        assert _unpack_handler_entry("not-a-tuple") is None
+        assert _unpack_handler_entry(None) is None
+        assert _unpack_handler_entry([lambda: None, False]) is None
+
+    def test_wrong_arity_rejected(self) -> None:
+        """Tuples of wrong arity are rejected."""
+        from hamster_mcp.mcp._core.hass_group import _unpack_handler_entry
+
+        def handler() -> None: ...  # pragma: no cover - never called
+
+        assert _unpack_handler_entry((handler,)) is None
+        assert _unpack_handler_entry((handler, False, "extra")) is None
+
+    def test_non_callable_handler_rejected(self) -> None:
+        """Tuples with a non-callable handler are rejected."""
+        from hamster_mcp.mcp._core.hass_group import _unpack_handler_entry
+
+        assert _unpack_handler_entry(("not-callable", False)) is None
+
+
+class TestDiscoverCommandsShapeGuard:
+    """Tests that discover_commands defends against registry shape drift."""
+
+    def test_skips_malformed_entries(self) -> None:
+        """Malformed entries are skipped rather than raising."""
+
+        def good_handler() -> None: ...  # pragma: no cover - never called
+
+        registry = {
+            "good_command": (good_handler, False),
+            "bad_string": "not-a-tuple",
+            "bad_arity": (good_handler,),
+            "bad_handler": ("not-callable", False),
+        }
+
+        commands = discover_commands(registry)  # type: ignore[arg-type]
+
+        assert "good_command" in commands
+        assert "bad_string" not in commands
+        assert "bad_arity" not in commands
+        assert "bad_handler" not in commands
+
 
 class TestVoluptuousConversion:
     """Tests for voluptuous schema conversion."""


### PR DESCRIPTION
Closes #152

## Summary

Tightens the internal WebSocket command execution path used by `HassGroup`. The path still depends on private HA state (`hass.data["websocket_api"]`), but now matches HA's connection contract more closely and refuses commands / inputs it cannot safely execute.

## Connection contract
- Add `set_supported_features` (mirrors `ActiveConnection`) plus `can_coalesce`, `last_id`, `refresh_token_id` attributes so handlers that touch them do not raise `AttributeError`.

## Command filtering
- Broaden `_is_filtered_command` to match `subscribe`/`unsubscribe` anywhere in the path, so `*_platforms/subscribe`-style names are filtered alongside the existing prefix-match commands.
- Explicitly filter `render_template` (event-producing), `supported_features` (connection lifecycle), and `fire_event` (side-effectful) which the pattern filter alone does not cover.

## Validation
- When `schema is False`, reject extra params with a `vol.Invalid`-equivalent error, matching HA's `connection.async_handle` behavior (only `id` and `type` allowed).
- Reject unknown `user_id` with an explicit error instead of falling through as anonymous, which would silently widen the trust boundary.

## Serialization
- Update `_orjson_default` to mirror HA's `json_encoder_default`: handle `json_fragment` attribute, sets, tuples, `Path`, `datetime`, in addition to the existing `as_dict()` path. Handlers returning HA-extension JSON types now round-trip the same way HA's real WebSocket connection would serialize them.

## Registry shape guard
- Add `_unpack_handler_entry` helper and use it at both registry destructuring sites (discovery and invocation) so unexpected shapes surface a clean error instead of raising `ValueError` from tuple unpacking.

## Tests

Real-HA-registry integration tests (using the actual handlers shipped by HA, not hand-rolled tuples):
- `get_states` success and extra-parameter failure
- `supported_features` / `render_template` / `fire_event` filtered out
- unknown `user_id` rejection

Unit tests:
- `schema=False` extra-key validation
- unknown user rejection
- registry shape guard (non-tuple, wrong arity, non-callable handler)
- broadened filter (subscribe-in-path, render_template, supported_features, fire_event)
- HA-extension serialization (set, tuple, datetime, Path, json_fragment)

## Verification

```
python -m pytest src/hamster_mcp        # 665 passed
python -m ruff check src/hamster_mcp    # All checks passed
python -m ruff format --check src/hamster_mcp
python -m mypy src/hamster_mcp          # Success: no issues found
```
