### PR TITLE
Improve service schema output

### DIFF
--- a/src/hamster_mcp/mcp/_core/groups.py
+++ b/src/hamster_mcp/mcp/_core/groups.py
@@ -9,13 +9,15 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass, field
 import json
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 from .events import Done, FormatServiceResponse, ServiceCall, ToolEffect
 from .selector_schemas import (
     SELECTOR_TYPES,
+    get_configured_selector_schema,
     get_selector_list_schema,
     get_selector_schema,
+    get_target_schema,
 )
 from .types import CallToolResult, TextContent
 
@@ -330,11 +332,12 @@ class ServicesGroup:
 
         # Target config
         target = service_data.get("target")
-        if target:
+        has_target = "target" in service_data
+        if has_target:
             lines.append("")
             lines.append("### Target")
             lines.append('*(use `schema("selector/target")` for full JSON Schema)*')
-            if isinstance(target, dict):
+            if isinstance(target, dict) and target:
                 if entity := target.get("entity"):
                     lines.append(f"- Entity: {entity}")
                 if device := target.get("device"):
@@ -353,7 +356,7 @@ class ServicesGroup:
             self._format_fields(fields, lines, selector_types_used=selector_types_used)
 
         # Schema references section
-        if selector_types_used or target:
+        if selector_types_used or has_target:
             lines.append("")
             lines.append("### Schema References")
             lines.append(
@@ -535,92 +538,217 @@ Use `schema("selector/<type>")` to get the JSON Schema for a specific type."""
     def _format_service_schema(
         self, domain: str, service: str, service_data: dict[str, object]
     ) -> str:
-        """Format service parameters as JSON Schema."""
-        fields = service_data.get("fields")
-        if not isinstance(fields, dict) or not fields:
+        """Format service call arguments as JSON Schema."""
+        raw_fields = service_data.get("fields")
+        fields = cast(
+            "dict[str, object] | None",
+            raw_fields if isinstance(raw_fields, dict) and raw_fields else None,
+        )
+        has_target = "target" in service_data
+
+        if fields is None and not has_target:
             return f"Service {domain}.{service} has no parameters."
 
-        # Build JSON Schema for service parameters
         properties: dict[str, Any] = {}
-        required_fields: list[str] = []
+        required_args: list[str] = []
 
-        for field_name, field_data in fields.items():
-            if not isinstance(field_data, dict):
-                continue
+        if has_target:
+            target_schema = get_target_schema()
+            target_schema["description"] = "Service target. Pass as `arguments.target`."
+            target_config = service_data.get("target")
+            if isinstance(target_config, dict) and target_config:
+                target_schema["x-ha-target-config"] = copy.deepcopy(target_config)
+            properties["target"] = target_schema
 
-            # Skip sections (nested field groups) for now
-            if "fields" in field_data:
-                continue
-
-            is_required = field_data.get("required", False)
-            selector = field_data.get("selector", {})
-            desc = field_data.get("description", "")
-
-            # Determine selector type
-            selector_type = None
-            if isinstance(selector, dict) and selector:
-                selector_keys = list(selector.keys())
-                if selector_keys:
-                    selector_type = selector_keys[0]
-
-            # Build field schema
-            field_schema: dict[str, Any] = {}
-            if selector_type:
-                # Get base schema from selector type
-                base_schema = get_selector_schema(selector_type)
-                if base_schema:
-                    field_schema = copy.deepcopy(base_schema)
-                else:
-                    field_schema["x-selector-type"] = selector_type
-
-            # Override description with service-specific one
-            if isinstance(desc, str) and desc:
-                field_schema["description"] = desc
-
-            properties[field_name] = field_schema
-
-            if is_required:
-                required_fields.append(field_name)
+        if fields is not None:
+            data_schema, required_fields = self._build_service_data_schema(
+                domain, service, fields
+            )
+            properties["data"] = data_schema
+            if required_fields:
+                required_args.append("data")
 
         schema: dict[str, Any] = {
             "type": "object",
+            "description": (
+                f"Arguments for `call` with path `services/{domain}.{service}`. "
+                "Use `target` for what to act on and `data` for service fields."
+            ),
             "properties": properties,
         }
-        if required_fields:
-            schema["required"] = required_fields
+        if required_args:
+            schema["required"] = required_args
 
         json_block = json.dumps(schema, indent=2)
 
         # Build markdown summary
-        markdown_parts = [f"## {domain}.{service} Parameters", ""]
+        markdown_parts = [
+            f"## {domain}.{service} Call Arguments",
+            "",
+            (
+                "Pass this object as the `arguments` value when calling "
+                f"`services/{domain}.{service}`."
+            ),
+            "",
+        ]
 
+        if has_target:
+            markdown_parts.extend(
+                [
+                    "### `arguments.target`",
+                    "",
+                    (
+                        "Service accepts a target object for entities, devices, "
+                        "areas, floors, or labels."
+                    ),
+                    "",
+                ]
+            )
+
+        if fields is not None:
+            markdown_parts.extend(
+                [
+                    "### `arguments.data`",
+                    "",
+                    "Service data fields:",
+                ]
+            )
+            self._format_service_schema_fields(fields, markdown_parts)
+
+        return f"```json\n{json_block}\n```\n\n" + "\n".join(markdown_parts)
+
+    def _build_service_data_schema(
+        self, domain: str, service: str, fields: dict[str, object]
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Build the ``arguments.data`` schema for service fields."""
+        properties: dict[str, Any] = {}
+        required_fields: list[str] = []
+        self._collect_service_field_schemas(fields, properties, required_fields)
+
+        schema: dict[str, Any] = {
+            "type": "object",
+            "description": (
+                f"Service data for `{domain}.{service}`. Pass as `arguments.data`."
+            ),
+            "properties": properties,
+        }
+        if required_fields:
+            schema["required"] = required_fields
+        return schema, required_fields
+
+    def _collect_service_field_schemas(
+        self,
+        fields: dict[str, object],
+        properties: dict[str, Any],
+        required_fields: list[str],
+        section: str | None = None,
+    ) -> None:
+        """Collect service field schemas, flattening HA presentation sections."""
         for field_name, field_data in fields.items():
             if not isinstance(field_data, dict):
                 continue
 
-            # Handle sections
+            if "fields" in field_data:
+                nested_fields = field_data.get("fields")
+                section_name = field_data.get("name", field_name)
+                if isinstance(nested_fields, dict):
+                    self._collect_service_field_schemas(
+                        cast("dict[str, object]", nested_fields),
+                        properties,
+                        required_fields,
+                        section_name if isinstance(section_name, str) else field_name,
+                    )
+                continue
+
+            field_schema = self._build_service_field_schema(field_data)
+            if section is not None:
+                field_schema["x-ha-section"] = section
+            properties[field_name] = field_schema
+
+            if field_data.get("required", False):
+                required_fields.append(field_name)
+
+    def _build_service_field_schema(
+        self, field_data: dict[object, object]
+    ) -> dict[str, Any]:
+        """Build a JSON Schema fragment for one HA service field."""
+        selector_type, selector_config = self._selector_type_and_config(
+            field_data.get("selector", {})
+        )
+
+        field_schema: dict[str, Any] = {}
+        if selector_type is not None:
+            selector_schema = get_configured_selector_schema(
+                selector_type, selector_config
+            )
+            if selector_schema is None:
+                field_schema["x-selector-type"] = selector_type
+            else:
+                field_schema = selector_schema
+
+        desc = field_data.get("description", "")
+        if isinstance(desc, str) and desc:
+            field_schema["description"] = desc
+
+        name = field_data.get("name")
+        if isinstance(name, str) and name:
+            field_schema["title"] = name
+
+        if "example" in field_data:
+            field_schema["examples"] = [copy.deepcopy(field_data["example"])]
+        if "default" in field_data:
+            field_schema["default"] = copy.deepcopy(field_data["default"])
+        if filter_config := field_data.get("filter"):
+            field_schema["x-ha-filter"] = copy.deepcopy(filter_config)
+
+        return field_schema
+
+    @staticmethod
+    def _selector_type_and_config(selector: object) -> tuple[str | None, object]:
+        """Return HA selector discriminator and config from a selector object."""
+        if not isinstance(selector, dict) or not selector:
+            return None, {}
+
+        selector_type = next(iter(selector))
+        if not isinstance(selector_type, str):
+            return None, {}
+        return selector_type, selector.get(selector_type, {})
+
+    def _format_service_schema_fields(
+        self, fields: dict[str, object], markdown_parts: list[str], indent: str = ""
+    ) -> None:
+        """Format service fields for the service schema markdown section."""
+        for field_name, field_data in fields.items():
+            if not isinstance(field_data, dict):
+                continue
+
             if "fields" in field_data:
                 section_name = field_data.get("name", field_name)
-                markdown_parts.append(f"**{section_name}** (section)")
+                markdown_parts.append(
+                    f"{indent}- **{section_name}** "
+                    "(section; fields flatten into `arguments.data`)"
+                )
+                nested_fields = field_data.get("fields")
+                if isinstance(nested_fields, dict):
+                    self._format_service_schema_fields(
+                        cast("dict[str, object]", nested_fields),
+                        markdown_parts,
+                        indent + "  ",
+                    )
                 continue
 
             is_required = field_data.get("required", False)
-            selector = field_data.get("selector", {})
+            selector_type, _selector_config = self._selector_type_and_config(
+                field_data.get("selector", {})
+            )
             desc = field_data.get("description", "")
 
-            selector_type = ""
-            if isinstance(selector, dict) and selector:
-                selector_keys = list(selector.keys())
-                if selector_keys:
-                    selector_type = f" [{selector_keys[0]}]"
-
+            selector_info = f" [{selector_type}]" if selector_type is not None else ""
             req_str = " (required)" if is_required else ""
-            line = f"- **{field_name}**{req_str}{selector_type}"
+            line = f"{indent}- **{field_name}**{req_str}{selector_info}"
             if isinstance(desc, str) and desc:
                 line += f": {desc}"
             markdown_parts.append(line)
-
-        return f"```json\n{json_block}\n```\n\n" + "\n".join(markdown_parts)
 
     def has_command(self, path: str) -> bool:
         """Check if a service exists."""

--- a/src/hamster_mcp/mcp/_core/selector_schemas.py
+++ b/src/hamster_mcp/mcp/_core/selector_schemas.py
@@ -15,6 +15,7 @@ This module provides:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import copy
 from typing import Any
 
@@ -319,6 +320,137 @@ def get_selector_schema(selector_type: str) -> dict[str, Any] | None:
         JSON Schema dict for the selector, or None if unknown type.
     """
     return SELECTOR_SCHEMAS.get(selector_type)
+
+
+def get_configured_selector_schema(
+    selector_type: str,
+    selector_config: object,
+) -> dict[str, Any] | None:
+    """Get a selector schema with service-specific selector config applied.
+
+    Home Assistant selector config is partly runtime shape and partly frontend UI
+    metadata. This applies safe JSON Schema constraints and preserves the full
+    HA config under ``x-ha-selector-config`` for callers that need the original
+    details.
+    """
+    base_schema = get_selector_schema(selector_type)
+    if base_schema is None:
+        return None
+
+    schema = copy.deepcopy(base_schema)
+    if not isinstance(selector_config, Mapping):
+        return schema
+
+    config = dict(selector_config)
+    if config:
+        schema["x-ha-selector-config"] = copy.deepcopy(config)
+
+    if selector_type in {"number", "color_temp"}:
+        _apply_numeric_config(schema, config)
+    elif selector_type == "select":
+        _apply_select_config(schema, config)
+    elif selector_type == "constant":
+        _apply_constant_config(schema, config)
+
+    if selector_type in {"area", "device", "entity", "floor", "label", "select"}:
+        _apply_multiple_config(schema, config)
+
+    if filter_config := config.get("filter"):
+        schema["x-ha-filter"] = copy.deepcopy(filter_config)
+
+    return schema
+
+
+def _apply_numeric_config(schema: dict[str, Any], config: dict[object, object]) -> None:
+    """Apply numeric selector config as JSON Schema constraints."""
+    if isinstance(config.get("min"), int | float):
+        schema["minimum"] = config["min"]
+    if isinstance(config.get("max"), int | float):
+        schema["maximum"] = config["max"]
+
+    step = config.get("step")
+    if isinstance(step, int | float) and step > 0:
+        schema["multipleOf"] = step
+
+    unit = config.get("unit_of_measurement", config.get("unit"))
+    if isinstance(unit, str):
+        schema["x-ha-unit-of-measurement"] = unit
+
+
+def _apply_select_config(schema: dict[str, Any], config: dict[object, object]) -> None:
+    """Apply select options when they form a closed set."""
+    options = config.get("options")
+    if not isinstance(options, list):
+        return
+
+    schema["x-ha-options"] = copy.deepcopy(options)
+    values: list[object] = []
+    for option in options:
+        if isinstance(option, str | int | float | bool):
+            values.append(option)
+        elif isinstance(option, Mapping) and "value" in option:
+            values.append(option["value"])
+        else:
+            return
+
+    if values and not config.get("custom_value", False):
+        schema["enum"] = values
+
+
+def _apply_constant_config(
+    schema: dict[str, Any], config: dict[object, object]
+) -> None:
+    """Apply constant selector value."""
+    if "value" not in config:
+        return
+
+    value = config["value"]
+    schema["const"] = value
+    json_type = _json_type(value)
+    if json_type is not None:
+        schema["type"] = json_type
+
+
+def _apply_multiple_config(
+    schema: dict[str, Any], config: dict[object, object]
+) -> None:
+    """Convert scalar selector output to an array when HA allows multiples."""
+    if config.get("multiple") is not True or schema.get("type") == "array":
+        return
+
+    item_schema = copy.deepcopy(schema)
+    description = schema.get("description")
+    schema.clear()
+    schema["type"] = "array"
+    schema["items"] = item_schema
+    if isinstance(description, str):
+        schema["description"] = f"List of {description[:1].lower()}{description[1:]}"
+
+    for key in (
+        "x-selector-type",
+        "x-ha-selector-config",
+        "x-ha-options",
+        "x-ha-filter",
+    ):
+        if key in item_schema:
+            schema[key] = copy.deepcopy(item_schema[key])
+
+
+def _json_type(value: object) -> str | None:
+    """Return the JSON Schema type name for a Python value."""
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int | float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    if value is None:
+        return "null"
+    return None
 
 
 def get_selector_list_schema() -> dict[str, Any]:

--- a/src/hamster_mcp/mcp/_core/selector_schemas.py
+++ b/src/hamster_mcp/mcp/_core/selector_schemas.py
@@ -352,11 +352,11 @@ def get_configured_selector_schema(
     elif selector_type == "constant":
         _apply_constant_config(schema, config)
 
-    if selector_type in {"area", "device", "entity", "floor", "label", "select"}:
-        _apply_multiple_config(schema, config)
-
     if filter_config := config.get("filter"):
         schema["x-ha-filter"] = copy.deepcopy(filter_config)
+
+    if selector_type in {"area", "device", "entity", "floor", "label", "select"}:
+        _apply_multiple_config(schema, config)
 
     return schema
 

--- a/src/hamster_mcp/mcp/_tests/test_groups.py
+++ b/src/hamster_mcp/mcp/_tests/test_groups.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 import pytest
 
 from hamster_mcp.mcp._core.events import Done, FormatServiceResponse, ServiceCall
 from hamster_mcp.mcp._core.groups import GroupRegistry, ServicesGroup, SourceGroup
+
+
+def _parse_json_schema(result: str) -> dict[str, Any]:
+    """Parse the leading JSON schema block from a schema() response."""
+    _prefix, rest = result.split("```json\n", 1)
+    json_block, _suffix = rest.split("\n```", 1)
+    parsed = json.loads(json_block)
+    assert isinstance(parsed, dict)
+    return parsed
+
 
 # --- SourceGroup protocol tests ---
 
@@ -345,6 +358,14 @@ class TestServicesGroupExplain:
         # Check for target schema hint
         assert 'schema("selector/target")' in result
 
+    def test_explain_includes_bare_target(self) -> None:
+        """explain() includes target when HA describes a service with bare target:."""
+        group = ServicesGroup.create({"homeassistant": {"turn_on": {"target": None}}})
+        result = group.explain("homeassistant.turn_on")
+        assert result is not None
+        assert "### Target" in result
+        assert "Accepts target specification" in result
+
 
 class TestServicesGroupSchema:
     """Tests for ServicesGroup.schema()."""
@@ -378,6 +399,119 @@ class TestServicesGroupSchema:
         assert result is not None
         assert "brightness" in result
         assert "required" in result
+
+        schema = _parse_json_schema(result)
+        properties = schema["properties"]
+        assert "data" in properties
+        assert "brightness" in properties["data"]["properties"]
+        assert schema["required"] == ["data"]
+        assert properties["data"]["required"] == ["brightness"]
+
+    def test_schema_target_only_service_includes_target(self) -> None:
+        """schema() includes target for services with target but no data fields."""
+        group = ServicesGroup.create({"homeassistant": {"turn_on": {"target": None}}})
+        result = group.schema("homeassistant.turn_on")
+        assert result is not None
+        assert "has no parameters" not in result
+        assert "arguments.target" in result
+
+        schema = _parse_json_schema(result)
+        properties = schema["properties"]
+        assert "target" in properties
+        assert "data" not in properties
+        assert "entity_id" in properties["target"]["properties"]
+
+    def test_schema_service_preserves_selector_constraints(self) -> None:
+        """schema() merges safe selector config into field JSON Schema."""
+        group = ServicesGroup.create(
+            {
+                "light": {
+                    "turn_on": {
+                        "target": {"entity": {"domain": "light"}},
+                        "fields": {
+                            "brightness_pct": {
+                                "selector": {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 100,
+                                        "unit_of_measurement": "%",
+                                    }
+                                }
+                            },
+                            "effect": {
+                                "selector": {
+                                    "select": {
+                                        "options": ["rainbow", "pulse"],
+                                    }
+                                }
+                            },
+                            "entity_ids": {
+                                "selector": {
+                                    "entity": {
+                                        "multiple": True,
+                                        "filter": {"domain": "light"},
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            }
+        )
+        result = group.schema("light.turn_on")
+        assert result is not None
+        schema = _parse_json_schema(result)
+        assert schema["properties"]["target"]["x-ha-target-config"] == {
+            "entity": {"domain": "light"}
+        }
+        data_properties = schema["properties"]["data"]["properties"]
+
+        brightness = data_properties["brightness_pct"]
+        assert brightness["minimum"] == 0
+        assert brightness["maximum"] == 100
+        assert brightness["x-ha-unit-of-measurement"] == "%"
+
+        effect = data_properties["effect"]
+        assert effect["enum"] == ["rainbow", "pulse"]
+        assert effect["x-ha-options"] == ["rainbow", "pulse"]
+
+        entity_ids = data_properties["entity_ids"]
+        assert entity_ids["type"] == "array"
+        assert entity_ids["items"]["type"] == "string"
+        assert entity_ids["x-ha-filter"] == {"domain": "light"}
+
+    def test_schema_service_flattens_section_fields(self) -> None:
+        """schema() flattens HA section fields into arguments.data."""
+        group = ServicesGroup.create(
+            {
+                "light": {
+                    "turn_on": {
+                        "fields": {
+                            "additional_fields": {
+                                "name": "Additional fields",
+                                "collapsed": True,
+                                "fields": {
+                                    "color_name": {
+                                        "selector": {
+                                            "select": {"options": ["red", "blue"]}
+                                        }
+                                    }
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        result = group.schema("light.turn_on")
+        assert result is not None
+        assert "fields flatten into `arguments.data`" in result
+
+        schema = _parse_json_schema(result)
+        data_properties = schema["properties"]["data"]["properties"]
+        assert "additional_fields" not in data_properties
+        assert data_properties["color_name"]["enum"] == ["red", "blue"]
+        assert data_properties["color_name"]["x-ha-section"] == "Additional fields"
 
     def test_schema_unknown_service(self) -> None:
         """schema() returns None for unknown service."""

--- a/src/hamster_mcp/mcp/_tests/test_groups.py
+++ b/src/hamster_mcp/mcp/_tests/test_groups.py
@@ -478,6 +478,7 @@ class TestServicesGroupSchema:
         entity_ids = data_properties["entity_ids"]
         assert entity_ids["type"] == "array"
         assert entity_ids["items"]["type"] == "string"
+        assert entity_ids["items"]["x-ha-filter"] == {"domain": "light"}
         assert entity_ids["x-ha-filter"] == {"domain": "light"}
 
     def test_schema_service_flattens_section_fields(self) -> None:

--- a/src/hamster_mcp/mcp/_tests/test_tools.py
+++ b/src/hamster_mcp/mcp/_tests/test_tools.py
@@ -309,6 +309,23 @@ class TestCallTool:
         assert isinstance(result, Done)
         text = result.result.content[0].text  # type: ignore[union-attr]
         assert "brightness" in text
+        assert "arguments.data" in text
+
+    def test_schema_target_only_service_fields(self) -> None:
+        registry = GroupRegistry()
+        group = ServicesGroup.create({"homeassistant": {"turn_on": {"target": None}}})
+        registry.register(group)
+        result = call_tool(
+            "schema",
+            {"path": "services/homeassistant.turn_on"},
+            registry,
+            user_id=None,
+            resources=(),
+        )
+        assert isinstance(result, Done)
+        text = result.result.content[0].text  # type: ignore[union-attr]
+        assert "has no parameters" not in text
+        assert "arguments.target" in text
 
     def test_schema_unknown_path_error(self) -> None:
         registry = self._make_registry()


### PR DESCRIPTION
## Summary

- Generate service schemas around the actual `call` argument shape, including `arguments.target` and `arguments.data`.
- Include target-only services and preserve populated HA target config.
- Merge safe selector constraints such as numeric ranges, select options, multiplicity, and filters while preserving HA selector metadata.
- Flatten HA section fields into `arguments.data` because sections are presentation-only.

Closes #153

## Verification

- `mise exec -- ruff format --check .`
- `mise exec -- ruff check .`
- `mise exec -- mypy`
- `mise exec -- pytest src/`
