### PR TITLE
Sync selector schemas with HA registry

### DIFF
--- a/docs/src/project/tool-generation.md
+++ b/docs/src/project/tool-generation.md
@@ -55,8 +55,10 @@ Rather than translating selectors to JSON Schema (as the previous per-service
 tool design required), the meta-tool pattern exposes them as-is via `explain`
 and documents their expected input formats via `schema`.
 
-The `SELECTOR_DESCRIPTIONS` mapping in `_core/tools.py` provides a
-human-readable description of each selector type's expected input format.
+The `SELECTOR_SCHEMAS` mapping in `_core/selector_schemas.py` provides a
+curated JSON Schema description of each selector type's expected input format.
+Its keys are tested against Home Assistant's selector registry so the catalog
+tracks the supported HA version under test.
 Examples:
 
 | Selector | Expected input |

--- a/src/hamster_mcp/mcp/_core/resources/insights/selectors.md
+++ b/src/hamster_mcp/mcp/_core/resources/insights/selectors.md
@@ -23,7 +23,9 @@ Use `schema("selector")` to get a list of all available selector types:
 }
 ```
 
-The `x-selector-types` annotation lists all valid selector type names.
+The `x-selector-types` annotation lists all valid selector type names from
+Home Assistant's backend selector registry. The schema bodies are curated JSON
+Schema summaries for MCP clients.
 
 ## JSON Schema Output
 

--- a/src/hamster_mcp/mcp/_core/selector_schemas.py
+++ b/src/hamster_mcp/mcp/_core/selector_schemas.py
@@ -32,7 +32,8 @@ def _string_or_array(description: str) -> dict[str, Any]:
 
 
 # JSON Schema definitions for each selector type.
-# Keys match HA's selector type names exactly.
+# Keys mirror homeassistant.helpers.selector.SELECTORS exactly; schema bodies are
+# curated for MCP clients rather than generated from HA's voluptuous validators.
 SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
     "action": {
         "type": "array",
@@ -44,6 +45,11 @@ SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
         "type": "string",
         "x-selector-type": "addon",
         "description": "Home Assistant add-on slug",
+    },
+    "app": {
+        "type": "string",
+        "x-selector-type": "app",
+        "description": "Home Assistant app slug",
     },
     "area": {
         "type": "string",
@@ -69,6 +75,37 @@ SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
         "type": "boolean",
         "x-selector-type": "boolean",
         "description": "Boolean value: true or false",
+    },
+    "choose": {
+        "x-selector-type": "choose",
+        "description": (
+            "Value matching one of the configured selector choices. "
+            "Object-form values include active_choice and a property named "
+            "for the active choice."
+        ),
+        "oneOf": [
+            {
+                "type": "object",
+                "description": "Object form for an explicit active choice",
+                "properties": {
+                    "active_choice": {
+                        "type": "string",
+                        "description": (
+                            "Choice key selected from the configured choices"
+                        ),
+                    }
+                },
+                "required": ["active_choice"],
+                "additionalProperties": True,
+            },
+            {
+                "not": {"type": "object"},
+                "description": (
+                    "Direct value form, validated against the configured "
+                    "choice selectors in order"
+                ),
+            },
+        ],
     },
     "color_rgb": {
         "type": "array",
@@ -195,11 +232,6 @@ SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
             "media_content_type": {"type": "string"},
         },
     },
-    "navigation": {
-        "type": "string",
-        "x-selector-type": "navigation",
-        "description": "Navigation path within Home Assistant",
-    },
     "number": {
         "type": "number",
         "x-selector-type": "number",
@@ -215,22 +247,12 @@ SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
         "x-selector-type": "qr_code",
         "description": "QR code data",
     },
-    "schedule": {
-        "type": "object",
-        "x-selector-type": "schedule",
-        "description": "Schedule definition object",
-    },
     "select": {
         "type": "string",
         "x-selector-type": "select",
         "description": (
             "One of a fixed set of string options (see service for valid values)"
         ),
-    },
-    "selector": {
-        "type": "object",
-        "x-selector-type": "selector",
-        "description": "A selector definition object (meta-type)",
     },
     "state": {
         "type": "string",
@@ -241,11 +263,6 @@ SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
         "type": "string",
         "x-selector-type": "statistic",
         "description": "Statistic ID for long-term statistics",
-    },
-    "stt": {
-        "type": "string",
-        "x-selector-type": "stt",
-        "description": "Speech-to-text engine ID",
     },
     "target": {
         "type": "object",
@@ -288,21 +305,6 @@ SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
         "type": "object",
         "x-selector-type": "trigger",
         "description": "An automation trigger definition",
-    },
-    "tts": {
-        "type": "string",
-        "x-selector-type": "tts",
-        "description": "Text-to-speech engine ID",
-    },
-    "ui_action": {
-        "type": "object",
-        "x-selector-type": "ui_action",
-        "description": "UI action definition",
-    },
-    "ui_color": {
-        "type": "string",
-        "x-selector-type": "ui_color",
-        "description": "UI color value",
     },
 }
 

--- a/src/hamster_mcp/mcp/_core/selector_schemas.py
+++ b/src/hamster_mcp/mcp/_core/selector_schemas.py
@@ -19,6 +19,8 @@ from collections.abc import Mapping
 import copy
 from typing import Any
 
+from homeassistant.helpers.selector import SELECTORS as HA_SELECTOR_TYPES
+
 
 def _string_or_array(description: str) -> dict[str, Any]:
     """Create a schema for a value that can be string or array of strings."""
@@ -31,10 +33,11 @@ def _string_or_array(description: str) -> dict[str, Any]:
     }
 
 
-# JSON Schema definitions for each selector type.
-# Keys mirror homeassistant.helpers.selector.SELECTORS exactly; schema bodies are
-# curated for MCP clients rather than generated from HA's voluptuous validators.
-SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
+# JSON Schema definitions for known selector types.
+# Schema bodies are curated for MCP clients rather than generated from HA's
+# voluptuous validators. The public SELECTOR_SCHEMAS below is filtered to the
+# selector types registered by the installed Home Assistant version.
+_KNOWN_SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
     "action": {
         "type": "array",
         "x-selector-type": "action",
@@ -306,6 +309,12 @@ SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
         "x-selector-type": "trigger",
         "description": "An automation trigger definition",
     },
+}
+
+SELECTOR_SCHEMAS: dict[str, dict[str, Any]] = {
+    selector_type: schema
+    for selector_type, schema in _KNOWN_SELECTOR_SCHEMAS.items()
+    if selector_type in HA_SELECTOR_TYPES
 }
 
 # Sorted list of all selector types for discovery

--- a/src/hamster_mcp/mcp/_tests/test_selector_schemas.py
+++ b/src/hamster_mcp/mcp/_tests/test_selector_schemas.py
@@ -1,0 +1,39 @@
+"""Tests for selector schema catalog parity."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from homeassistant.helpers.selector import SELECTORS
+
+from hamster_mcp.mcp._core.groups import ServicesGroup
+from hamster_mcp.mcp._core.selector_schemas import SELECTOR_SCHEMAS, SELECTOR_TYPES
+
+
+def _parse_json_schema(result: str) -> dict[str, Any]:
+    """Parse the leading JSON schema block from a schema() response."""
+    _prefix, rest = result.split("```json\n", 1)
+    json_block, _suffix = rest.split("\n```", 1)
+    parsed = json.loads(json_block)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_selector_catalog_matches_home_assistant_registry() -> None:
+    """The static schema catalog tracks HA's registered selector names."""
+    assert set(SELECTOR_SCHEMAS) == set(SELECTORS)
+    assert sorted(SELECTORS) == SELECTOR_TYPES
+
+
+def test_schema_resolves_each_registered_selector() -> None:
+    """schema("selector/<type>") works for every HA selector type."""
+    group = ServicesGroup.create({})
+
+    for selector_type in SELECTORS:
+        result = group.schema(f"selector/{selector_type}")
+
+        assert result is not None
+        parsed = _parse_json_schema(result)
+        assert parsed["x-selector-type"] == selector_type
+        assert isinstance(parsed.get("description"), str)


### PR DESCRIPTION
## Summary

- Sync selector schema catalog keys with Home Assistant's `SELECTORS` registry.
- Add schemas for `app` and `choose`, and remove non-registry selector entries.
- Add parity and schema-resolution tests for registered selector types.
- Document the catalog as tested registry-parity keys with curated schema bodies.

## Testing

- `mise exec -- uv run ruff format --check .`
- `mise exec -- uv run ruff check .`
- `mise exec -- uv run mypy`
- `mise exec -- uv run pytest src/`

Closes #154
