### PR TITLE
Update Supervisor group: apps terminology, log metadata, GET params, broader endpoint coverage

### DIFF
--- a/src/hamster_mcp/component/_tests/test_effect_handler.py
+++ b/src/hamster_mcp/component/_tests/test_effect_handler.py
@@ -287,6 +287,7 @@ class TestExecuteSupervisorCall:
                 path="/core/logs",
                 params={},
                 user_id="admin-user-123",
+                returns_text=True,
             )
 
         assert result.success is True
@@ -294,6 +295,41 @@ class TestExecuteSupervisorCall:
             "logs": "2024-01-01 INFO Starting...\n2024-01-01 INFO Ready"
         }
         assert result.error is None
+        # Confirm the text-vs-JSON decision came from the explicit
+        # returns_text flag, not from a path heuristic.
+        call_kwargs = mock_hassio.send_command.call_args.kwargs
+        assert call_kwargs["return_text"] is True
+
+    async def test_returns_text_for_non_logs_suffix(
+        self,
+        effect_handler: HamsterEffectHandler,
+        mock_hass: MagicMock,
+        mock_admin_user: MagicMock,
+        mock_hassio: MagicMock,
+    ) -> None:
+        """Endpoints like /logs/follow or /addons/.../changelog return text.
+
+        Verifies the call honors the explicit returns_text flag rather than
+        relying on path.endswith("/logs").
+        """
+        mock_hass.auth = MagicMock()
+        mock_hass.auth.async_get_user = AsyncMock(return_value=mock_admin_user)
+        mock_hass.data = {"hassio": mock_hassio}
+        mock_hassio.send_command.return_value = "streaming log line\n"
+
+        with patch.dict("sys.modules", mock_hassio_modules()):
+            result = await effect_handler.execute_supervisor_call(
+                method="GET",
+                path="/core/logs/follow",
+                params={},
+                user_id="admin-user-123",
+                returns_text=True,
+            )
+
+        assert result.success is True
+        assert result.data == {"logs": "streaming log line\n"}
+        call_kwargs = mock_hassio.send_command.call_args.kwargs
+        assert call_kwargs["return_text"] is True
 
     async def test_no_user_id_returns_auth_error(
         self,
@@ -444,7 +480,7 @@ class TestExecuteSupervisorCall:
         mock_admin_user: MagicMock,
         mock_hassio: MagicMock,
     ) -> None:
-        """Test POST method passes params as payload."""
+        """Test POST method passes params as payload (not query string)."""
         mock_hass.auth = MagicMock()
         mock_hass.auth.async_get_user = AsyncMock(return_value=mock_admin_user)
         mock_hass.data = {"hassio": mock_hassio}
@@ -461,3 +497,61 @@ class TestExecuteSupervisorCall:
         mock_hassio.send_command.assert_called_once()
         call_kwargs = mock_hassio.send_command.call_args.kwargs
         assert call_kwargs["payload"] == {"key": "value"}
+        assert call_kwargs["params"] is None
+
+    async def test_get_method_passes_query_params(
+        self,
+        effect_handler: HamsterEffectHandler,
+        mock_hass: MagicMock,
+        mock_admin_user: MagicMock,
+        mock_hassio: MagicMock,
+    ) -> None:
+        """GET requests must forward parameters as a query string.
+
+        Previously these were silently dropped, so endpoints that accept
+        query parameters (e.g. ``lines`` for log endpoints) would ignore
+        client input.
+        """
+        mock_hass.auth = MagicMock()
+        mock_hass.auth.async_get_user = AsyncMock(return_value=mock_admin_user)
+        mock_hass.data = {"hassio": mock_hassio}
+        mock_hassio.send_command.return_value = "log content"
+
+        with patch.dict("sys.modules", mock_hassio_modules()):
+            await effect_handler.execute_supervisor_call(
+                method="GET",
+                path="/core/logs",
+                params={"lines": "100"},
+                user_id="admin-user-123",
+                returns_text=True,
+            )
+
+        mock_hassio.send_command.assert_called_once()
+        call_kwargs = mock_hassio.send_command.call_args.kwargs
+        assert call_kwargs["params"] == {"lines": "100"}
+        assert call_kwargs["payload"] is None
+
+    async def test_get_method_with_empty_params_sends_none(
+        self,
+        effect_handler: HamsterEffectHandler,
+        mock_hass: MagicMock,
+        mock_admin_user: MagicMock,
+        mock_hassio: MagicMock,
+    ) -> None:
+        """GET with no params should not produce an empty query dict."""
+        mock_hass.auth = MagicMock()
+        mock_hass.auth.async_get_user = AsyncMock(return_value=mock_admin_user)
+        mock_hass.data = {"hassio": mock_hassio}
+        mock_hassio.send_command.return_value = {"data": {"ok": True}}
+
+        with patch.dict("sys.modules", mock_hassio_modules()):
+            await effect_handler.execute_supervisor_call(
+                method="GET",
+                path="/core/info",
+                params={},
+                user_id="admin-user-123",
+            )
+
+        call_kwargs = mock_hassio.send_command.call_args.kwargs
+        assert call_kwargs["params"] is None
+        assert call_kwargs["payload"] is None

--- a/src/hamster_mcp/component/_tests/test_multi_source_integration.py
+++ b/src/hamster_mcp/component/_tests/test_multi_source_integration.py
@@ -332,6 +332,49 @@ class TestSupervisorGroupFlow:
         assert effect.path == "/core/logs"
         assert effect.method == "GET"
         assert effect.user_id == "test_user"
+        # Endpoint definition declares this as a text response, so the effect
+        # must propagate that flag (rather than relying on path heuristics).
+        assert effect.returns_text is True
+
+        json_effect = supervisor_group.parse_call_args(
+            "core/info", {}, user_id="test_user"
+        )
+        assert isinstance(json_effect, SupervisorCall)
+        assert json_effect.returns_text is False
+
+    async def test_search_matches_apps_and_addons_terminology(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Searching for either "apps" or "add-ons" must surface addon endpoints.
+
+        HA 2026.6 rebranded add-ons to apps in user-facing surfaces; the
+        Supervisor REST paths still use ``/addons``. Descriptions use both
+        terms so search works regardless of which the user types.
+        """
+        with (
+            patch(
+                "hamster_mcp.component.async_get_all_descriptions",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch("hamster_mcp.component.is_supervisor_available", return_value=True),
+        ):
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        runtime = mock_config_entry.runtime_data
+        manager = runtime.manager
+
+        supervisor_group = manager._registry.get("supervisor")
+        assert supervisor_group is not None
+
+        apps_result = supervisor_group.search("apps")
+        assert "addons" in apps_result
+
+        addons_result = supervisor_group.search("add-on")
+        assert "addons" in addons_result
 
 
 class TestCrossGroupSearch:

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -513,11 +513,18 @@ class HamsterEffectHandler:
             # signature accepts a `params` kwarg for query parameters; pass
             # GET-style arguments there so they reach the Supervisor instead
             # of being silently dropped.
+            #
+            # Bound the timeout instead of passing None: the Supervisor's
+            # streaming /logs/follow variants never close on their own, and
+            # aiohttp.ClientTimeout(total=None) would block the call forever.
+            # 300 seconds is generous for large log retrievals while keeping
+            # streaming endpoints from holding an MCP request open
+            # indefinitely.
             result = await hassio.send_command(
                 path,
                 method=method.lower(),
                 payload=send_payload,
-                timeout=None,
+                timeout=300,
                 return_text=returns_text,
                 params=send_params,
             )

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -458,6 +458,8 @@ class HamsterEffectHandler:
         path: str,
         params: dict[str, object],
         user_id: str | None,
+        *,
+        returns_text: bool = False,
     ) -> SupervisorCallResult:
         """Execute a Supervisor API call.
 
@@ -466,6 +468,8 @@ class HamsterEffectHandler:
             path: API path (e.g. '/core/logs')
             params: Query params (GET) or body (POST)
             user_id: Authenticated user ID for authorization
+            returns_text: True for endpoints that return plain text (e.g. logs).
+                Determined by the endpoint definition, not inferred from the path.
 
         Returns:
             SupervisorCallResult indicating success or failure
@@ -496,17 +500,26 @@ class HamsterEffectHandler:
         if hassio is None:
             return SupervisorCallResult(success=False, error="Supervisor not available")
 
-        try:
-            # Determine if this returns text (logs) or JSON
-            returns_text = path.endswith("/logs")
+        # Split params between request body (for write methods) and query
+        # string (for read methods). Sending both would be ambiguous, so we
+        # pick exactly one based on the HTTP method.
+        method_upper = method.upper()
+        is_write = method_upper in ("POST", "PUT", "PATCH", "DELETE")
+        send_payload = params if is_write else None
+        send_params = None if is_write else (params or None)
 
-            # Use the hassio client to make the API call
+        try:
+            # Use the hassio client to make the API call. The send_command
+            # signature accepts a `params` kwarg for query parameters; pass
+            # GET-style arguments there so they reach the Supervisor instead
+            # of being silently dropped.
             result = await hassio.send_command(
                 path,
                 method=method.lower(),
-                payload=params if method.upper() in ("POST", "PUT", "PATCH") else None,
+                payload=send_payload,
                 timeout=None,
                 return_text=returns_text,
+                params=send_params,
             )
 
             if returns_text:

--- a/src/hamster_mcp/mcp/_core/events.py
+++ b/src/hamster_mcp/mcp/_core/events.py
@@ -99,6 +99,7 @@ class SupervisorCall:
     params: dict[str, object]  # Query params (GET) or body (POST)
     user_id: str | None
     continuation: Continuation
+    returns_text: bool = False  # True for endpoints that return plain text (logs)
 
 
 # ToolEffect union - what call_tool() and resume() return

--- a/src/hamster_mcp/mcp/_core/supervisor_group.py
+++ b/src/hamster_mcp/mcp/_core/supervisor_group.py
@@ -41,33 +41,254 @@ class EndpointInfo:
 # --- Endpoint definitions ---
 
 
+# Note on terminology: Home Assistant rebranded "add-ons" to "apps" in 2026.6
+# user-facing surfaces, but the Supervisor REST paths still use `/addons`.
+# Descriptions use "app (add-on)" so search hits work for either term while
+# keeping the legacy name visible to operators familiar with it.
+_APP_SLUG = {"type": "string", "description": "App (add-on) slug"}
+_BOOT_ID = {"type": "string", "description": "Boot identifier"}
+_UUID = {"type": "string", "description": "Discovery service UUID"}
+_BACKUP_SLUG = {"type": "string", "description": "Backup slug"}
+_INTERFACE = {"type": "string", "description": "Network interface name"}
+_JOB_UUID = {"type": "string", "description": "Job UUID"}
+
+
 SUPERVISOR_ENDPOINTS: dict[str, EndpointInfo] = {
-    "core/logs": EndpointInfo(
+    # --- Apps (formerly add-ons) ---
+    "addons": EndpointInfo(
         method="GET",
-        path="/core/logs",
-        description="Get Home Assistant Core logs",
+        path="/addons",
+        description="List installed apps (add-ons)",
+        params_schema={},
+    ),
+    "addons/{slug}/info": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/info",
+        description="Get app (add-on) information",
+        params_schema={"slug": _APP_SLUG},
+        path_params=("slug",),
+    ),
+    "addons/{slug}/stats": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/stats",
+        description="Get app (add-on) resource usage statistics",
+        params_schema={"slug": _APP_SLUG},
+        path_params=("slug",),
+    ),
+    "addons/{slug}/changelog": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/changelog",
+        description="Get app (add-on) changelog",
+        params_schema={"slug": _APP_SLUG},
+        path_params=("slug",),
+        returns_text=True,
+    ),
+    "addons/{slug}/documentation": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/documentation",
+        description="Get app (add-on) documentation",
+        params_schema={"slug": _APP_SLUG},
+        path_params=("slug",),
+        returns_text=True,
+    ),
+    "addons/{slug}/logs": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/logs",
+        description="Get app (add-on) logs from the Systemd journal",
+        params_schema={"slug": _APP_SLUG},
+        path_params=("slug",),
+        returns_text=True,
+    ),
+    "addons/{slug}/logs/follow": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/logs/follow",
+        description="Stream app (add-on) logs (continuous follow)",
+        params_schema={"slug": _APP_SLUG},
+        path_params=("slug",),
+        returns_text=True,
+    ),
+    "addons/{slug}/logs/latest": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/logs/latest",
+        description="Get logs from the latest startup of the app (add-on) container",
+        params_schema={"slug": _APP_SLUG},
+        path_params=("slug",),
+        returns_text=True,
+    ),
+    "addons/{slug}/logs/boots/{bootid}": EndpointInfo(
+        method="GET",
+        path="/addons/{slug}/logs/boots/{bootid}",
+        description="Get app (add-on) logs for a specific boot",
+        params_schema={"slug": _APP_SLUG, "bootid": _BOOT_ID},
+        path_params=("slug", "bootid"),
+        returns_text=True,
+    ),
+    # --- Audio plugin ---
+    "audio/info": EndpointInfo(
+        method="GET",
+        path="/audio/info",
+        description="Get audio plugin information",
+        params_schema={},
+    ),
+    "audio/stats": EndpointInfo(
+        method="GET",
+        path="/audio/stats",
+        description="Get audio plugin resource usage statistics",
+        params_schema={},
+    ),
+    "audio/logs": EndpointInfo(
+        method="GET",
+        path="/audio/logs",
+        description="Get audio plugin logs from the Systemd journal",
         params_schema={},
         returns_text=True,
     ),
+    "audio/logs/follow": EndpointInfo(
+        method="GET",
+        path="/audio/logs/follow",
+        description="Stream audio plugin logs (continuous follow)",
+        params_schema={},
+        returns_text=True,
+    ),
+    "audio/logs/latest": EndpointInfo(
+        method="GET",
+        path="/audio/logs/latest",
+        description="Get logs from the latest startup of the audio plugin container",
+        params_schema={},
+        returns_text=True,
+    ),
+    # --- Backups ---
+    "backups": EndpointInfo(
+        method="GET",
+        path="/backups",
+        description="List backups",
+        params_schema={},
+    ),
+    "backups/info": EndpointInfo(
+        method="GET",
+        path="/backups/info",
+        description="Get backup manager information",
+        params_schema={},
+    ),
+    "backups/{slug}/info": EndpointInfo(
+        method="GET",
+        path="/backups/{slug}/info",
+        description="Get details for a specific backup",
+        params_schema={"slug": _BACKUP_SLUG},
+        path_params=("slug",),
+    ),
+    # --- CLI plugin ---
+    "cli/info": EndpointInfo(
+        method="GET",
+        path="/cli/info",
+        description="Get CLI plugin information",
+        params_schema={},
+    ),
+    "cli/stats": EndpointInfo(
+        method="GET",
+        path="/cli/stats",
+        description="Get CLI plugin resource usage statistics",
+        params_schema={},
+    ),
+    # --- Home Assistant Core ---
     "core/info": EndpointInfo(
         method="GET",
         path="/core/info",
         description="Get Home Assistant Core information",
         params_schema={},
     ),
-    "supervisor/info": EndpointInfo(
+    "core/stats": EndpointInfo(
         method="GET",
-        path="/supervisor/info",
-        description="Get Supervisor information",
+        path="/core/stats",
+        description="Get Home Assistant Core resource usage statistics",
         params_schema={},
     ),
-    "supervisor/logs": EndpointInfo(
+    "core/logs": EndpointInfo(
         method="GET",
-        path="/supervisor/logs",
-        description="Get Supervisor logs",
+        path="/core/logs",
+        description="Get Home Assistant Core logs from the Systemd journal",
         params_schema={},
         returns_text=True,
     ),
+    "core/logs/follow": EndpointInfo(
+        method="GET",
+        path="/core/logs/follow",
+        description="Stream Home Assistant Core logs (continuous follow)",
+        params_schema={},
+        returns_text=True,
+    ),
+    "core/logs/latest": EndpointInfo(
+        method="GET",
+        path="/core/logs/latest",
+        description=(
+            "Get logs from the latest startup of the Home Assistant Core container"
+        ),
+        params_schema={},
+        returns_text=True,
+    ),
+    "core/logs/boots/{bootid}": EndpointInfo(
+        method="GET",
+        path="/core/logs/boots/{bootid}",
+        description="Get Home Assistant Core logs for a specific boot",
+        params_schema={"bootid": _BOOT_ID},
+        path_params=("bootid",),
+        returns_text=True,
+    ),
+    # --- Discovery ---
+    "discovery": EndpointInfo(
+        method="GET",
+        path="/discovery",
+        description="List enabled discovery services from apps (add-ons)",
+        params_schema={},
+    ),
+    "discovery/{uuid}": EndpointInfo(
+        method="GET",
+        path="/discovery/{uuid}",
+        description="Get a specific discovery service by UUID",
+        params_schema={"uuid": _UUID},
+        path_params=("uuid",),
+    ),
+    # --- DNS plugin ---
+    "dns/info": EndpointInfo(
+        method="GET",
+        path="/dns/info",
+        description="Get DNS plugin information",
+        params_schema={},
+    ),
+    "dns/stats": EndpointInfo(
+        method="GET",
+        path="/dns/stats",
+        description="Get DNS plugin resource usage statistics",
+        params_schema={},
+    ),
+    "dns/logs": EndpointInfo(
+        method="GET",
+        path="/dns/logs",
+        description="Get DNS plugin logs from the Systemd journal",
+        params_schema={},
+        returns_text=True,
+    ),
+    "dns/logs/latest": EndpointInfo(
+        method="GET",
+        path="/dns/logs/latest",
+        description="Get logs from the latest startup of the DNS plugin container",
+        params_schema={},
+        returns_text=True,
+    ),
+    # --- Hardware ---
+    "hardware/info": EndpointInfo(
+        method="GET",
+        path="/hardware/info",
+        description="Get hardware information",
+        params_schema={},
+    ),
+    "hardware/audio": EndpointInfo(
+        method="GET",
+        path="/hardware/audio",
+        description="Get audio hardware information",
+        params_schema={},
+    ),
+    # --- Host ---
     "host/info": EndpointInfo(
         method="GET",
         path="/host/info",
@@ -77,42 +298,177 @@ SUPERVISOR_ENDPOINTS: dict[str, EndpointInfo] = {
     "host/logs": EndpointInfo(
         method="GET",
         path="/host/logs",
-        description="Get host system logs",
+        description="Get host system logs from the Systemd journal",
         params_schema={},
         returns_text=True,
     ),
-    "addons": EndpointInfo(
+    "host/logs/follow": EndpointInfo(
         method="GET",
-        path="/addons",
-        description="List installed add-ons",
+        path="/host/logs/follow",
+        description="Stream host system logs (continuous follow)",
         params_schema={},
-    ),
-    "addons/{slug}/info": EndpointInfo(
-        method="GET",
-        path="/addons/{slug}/info",
-        description="Get add-on information",
-        params_schema={"slug": {"type": "string", "description": "Add-on slug"}},
-        path_params=("slug",),
-    ),
-    "addons/{slug}/logs": EndpointInfo(
-        method="GET",
-        path="/addons/{slug}/logs",
-        description="Get add-on logs",
-        params_schema={"slug": {"type": "string", "description": "Add-on slug"}},
-        path_params=("slug",),
         returns_text=True,
     ),
-    "backups": EndpointInfo(
+    "host/logs/latest": EndpointInfo(
         method="GET",
-        path="/backups",
-        description="List backups",
+        path="/host/logs/latest",
+        description="Get logs from the latest boot of the host system",
+        params_schema={},
+        returns_text=True,
+    ),
+    "host/logs/identifiers": EndpointInfo(
+        method="GET",
+        path="/host/logs/identifiers",
+        description="List Systemd journal identifiers available on the host",
         params_schema={},
     ),
+    "host/logs/boots": EndpointInfo(
+        method="GET",
+        path="/host/logs/boots",
+        description="List boot IDs known to the host journal",
+        params_schema={},
+    ),
+    # --- Jobs ---
+    "jobs/info": EndpointInfo(
+        method="GET",
+        path="/jobs/info",
+        description="Get information about Supervisor jobs",
+        params_schema={},
+    ),
+    "jobs/{uuid}": EndpointInfo(
+        method="GET",
+        path="/jobs/{uuid}",
+        description="Get information about a specific Supervisor job",
+        params_schema={"uuid": _JOB_UUID},
+        path_params=("uuid",),
+    ),
+    # --- Mounts ---
+    "mounts": EndpointInfo(
+        method="GET",
+        path="/mounts",
+        description="List configured network mounts",
+        params_schema={},
+    ),
+    # --- Multicast plugin ---
+    "multicast/info": EndpointInfo(
+        method="GET",
+        path="/multicast/info",
+        description="Get multicast plugin information",
+        params_schema={},
+    ),
+    "multicast/stats": EndpointInfo(
+        method="GET",
+        path="/multicast/stats",
+        description="Get multicast plugin resource usage statistics",
+        params_schema={},
+    ),
+    "multicast/logs": EndpointInfo(
+        method="GET",
+        path="/multicast/logs",
+        description="Get multicast plugin logs from the Systemd journal",
+        params_schema={},
+        returns_text=True,
+    ),
+    # --- Network ---
     "network/info": EndpointInfo(
         method="GET",
         path="/network/info",
         description="Get network information",
         params_schema={},
+    ),
+    "network/interface/{interface}/info": EndpointInfo(
+        method="GET",
+        path="/network/interface/{interface}/info",
+        description="Get information about a specific network interface",
+        params_schema={"interface": _INTERFACE},
+        path_params=("interface",),
+    ),
+    # --- Observer plugin ---
+    "observer/info": EndpointInfo(
+        method="GET",
+        path="/observer/info",
+        description="Get observer plugin information",
+        params_schema={},
+    ),
+    "observer/stats": EndpointInfo(
+        method="GET",
+        path="/observer/stats",
+        description="Get observer plugin resource usage statistics",
+        params_schema={},
+    ),
+    # --- Operating system ---
+    "os/info": EndpointInfo(
+        method="GET",
+        path="/os/info",
+        description="Get Home Assistant OS information",
+        params_schema={},
+    ),
+    # --- Resolution center ---
+    "resolution/info": EndpointInfo(
+        method="GET",
+        path="/resolution/info",
+        description="Get resolution center information (issues, suggestions, checks)",
+        params_schema={},
+    ),
+    # --- Services discovery ---
+    "services": EndpointInfo(
+        method="GET",
+        path="/services",
+        description="List services provided by apps (add-ons)",
+        params_schema={},
+    ),
+    # --- Store ---
+    "store": EndpointInfo(
+        method="GET",
+        path="/store",
+        description="Get app (add-on) store overview",
+        params_schema={},
+    ),
+    "store/addons": EndpointInfo(
+        method="GET",
+        path="/store/addons",
+        description="List apps (add-ons) available in the store",
+        params_schema={},
+    ),
+    "store/repositories": EndpointInfo(
+        method="GET",
+        path="/store/repositories",
+        description="List app (add-on) repositories configured in the store",
+        params_schema={},
+    ),
+    # --- Supervisor ---
+    "supervisor/info": EndpointInfo(
+        method="GET",
+        path="/supervisor/info",
+        description="Get Supervisor information",
+        params_schema={},
+    ),
+    "supervisor/stats": EndpointInfo(
+        method="GET",
+        path="/supervisor/stats",
+        description="Get Supervisor resource usage statistics",
+        params_schema={},
+    ),
+    "supervisor/logs": EndpointInfo(
+        method="GET",
+        path="/supervisor/logs",
+        description="Get Supervisor logs from the Systemd journal",
+        params_schema={},
+        returns_text=True,
+    ),
+    "supervisor/logs/follow": EndpointInfo(
+        method="GET",
+        path="/supervisor/logs/follow",
+        description="Stream Supervisor logs (continuous follow)",
+        params_schema={},
+        returns_text=True,
+    ),
+    "supervisor/logs/latest": EndpointInfo(
+        method="GET",
+        path="/supervisor/logs/latest",
+        description="Get logs from the latest startup of the Supervisor container",
+        params_schema={},
+        returns_text=True,
     ),
 }
 
@@ -373,4 +729,5 @@ class SupervisorGroup:
             params=remaining_args,
             user_id=user_id,
             continuation=FormatSupervisorResponse(),
+            returns_text=info.returns_text,
         )

--- a/src/hamster_mcp/mcp/_io/aiohttp.py
+++ b/src/hamster_mcp/mcp/_io/aiohttp.py
@@ -106,6 +106,8 @@ class EffectHandler(Protocol):
         path: str,
         params: dict[str, object],
         user_id: str | None,
+        *,
+        returns_text: bool = False,
     ) -> SupervisorCallResult:
         """Execute a Supervisor API call.
 
@@ -114,6 +116,7 @@ class EffectHandler(Protocol):
             path: API path (e.g. '/core/logs')
             params: Query params (GET) or body (POST)
             user_id: Authenticated user ID for authorization
+            returns_text: True for endpoints that return plain text (e.g. logs)
 
         Returns:
             SupervisorCallResult indicating success or failure
@@ -308,6 +311,7 @@ class AiohttpMCPTransport:
                             current.path,
                             current.params,
                             current.user_id,
+                            returns_text=current.returns_text,
                         )
                     )
                 except Exception as err:

--- a/src/hamster_mcp/mcp/_tests/test_aiohttp.py
+++ b/src/hamster_mcp/mcp/_tests/test_aiohttp.py
@@ -72,8 +72,8 @@ class MockEffectHandler:
     hass_calls: list[tuple[str, dict[str, object], str | None]] = field(
         default_factory=list
     )
-    supervisor_calls: list[tuple[str, str, dict[str, object], str | None]] = field(
-        default_factory=list
+    supervisor_calls: list[tuple[str, str, dict[str, object], str | None, bool]] = (
+        field(default_factory=list)
     )
     result: ServiceCallResult = field(default_factory=_default_service_result)
     hass_result: HassCommandResult = field(default_factory=_default_hass_result)
@@ -118,9 +118,11 @@ class MockEffectHandler:
         path: str,
         params: dict[str, object],
         user_id: str | None,
+        *,
+        returns_text: bool = False,
     ) -> SupervisorCallResult:
         """Execute mock supervisor call."""
-        self.supervisor_calls.append((method, path, params, user_id))
+        self.supervisor_calls.append((method, path, params, user_id, returns_text))
         if self.supervisor_should_raise is not None:
             raise self.supervisor_should_raise
         return self.supervisor_result

--- a/src/hamster_mcp/mcp/_tests/test_supervisor_group.py
+++ b/src/hamster_mcp/mcp/_tests/test_supervisor_group.py
@@ -278,6 +278,27 @@ class TestSupervisorGroupParseCallArgs:
         assert isinstance(result, SupervisorCall)
         assert result.params == {"lines": 100}
 
+    def test_returns_text_propagated_from_endpoint(self) -> None:
+        """The returns_text flag on the endpoint flows into the effect.
+
+        The transport relies on this flag instead of inferring text vs JSON
+        from path suffixes, so the endpoint definition is the source of
+        truth.
+        """
+        group = SupervisorGroup.create(available=True)
+
+        text_effect = group.parse_call_args("core/logs", {}, user_id=None)
+        assert isinstance(text_effect, SupervisorCall)
+        assert text_effect.returns_text is True
+
+        json_effect = group.parse_call_args("core/info", {}, user_id=None)
+        assert isinstance(json_effect, SupervisorCall)
+        assert json_effect.returns_text is False
+
+        follow_effect = group.parse_call_args("core/logs/follow", {}, user_id=None)
+        assert isinstance(follow_effect, SupervisorCall)
+        assert follow_effect.returns_text is True
+
 
 class TestEndpointInfo:
     """Tests for EndpointInfo dataclass."""
@@ -304,17 +325,54 @@ class TestEndpointInfo:
                 )
 
     def test_log_endpoints_return_text(self) -> None:
-        """Log endpoints have returns_text=True."""
+        """Endpoints that stream Systemd journal output have returns_text=True.
+
+        Endpoints whose key ends with ``/logs`` or contains ``/logs/follow``,
+        ``/logs/latest``, or ``/logs/boots/{bootid}`` return plain text and
+        must declare returns_text=True. Sibling endpoints under ``/logs/``
+        like ``/host/logs/identifiers`` and ``/host/logs/boots`` are
+        intentionally excluded because they return JSON listings, not log
+        text.
+        """
+        text_log_suffixes = (
+            "/logs",
+            "/logs/follow",
+            "/logs/latest",
+        )
         for path, info in SUPERVISOR_ENDPOINTS.items():
-            if "logs" in path:
+            api_path = info.path
+            is_text_log = (
+                any(api_path.endswith(suffix) for suffix in text_log_suffixes)
+                or "/logs/boots/{bootid}" in api_path
+            )
+            if is_text_log:
                 assert info.returns_text is True, (
                     f"Log endpoint '{path}' should have returns_text=True"
+                )
+
+    def test_non_log_endpoints_return_json(self) -> None:
+        """Endpoints that aren't log streams must return JSON."""
+        text_log_suffixes = ("/logs", "/logs/follow", "/logs/latest")
+        text_endpoints_with_other_paths = {
+            "addons/{slug}/changelog",
+            "addons/{slug}/documentation",
+        }
+        for path, info in SUPERVISOR_ENDPOINTS.items():
+            api_path = info.path
+            is_text = (
+                any(api_path.endswith(suffix) for suffix in text_log_suffixes)
+                or "/logs/boots/{bootid}" in api_path
+                or path in text_endpoints_with_other_paths
+            )
+            if not is_text:
+                assert info.returns_text is False, (
+                    f"Endpoint '{path}' should return JSON (returns_text=False)"
                 )
 
     def test_info_endpoints_return_json(self) -> None:
         """Info endpoints have returns_text=False (JSON)."""
         for path, info in SUPERVISOR_ENDPOINTS.items():
-            if "info" in path:
+            if path.endswith("/info") or "/info" in info.path:
                 assert info.returns_text is False, (
                     f"Info endpoint '{path}' should return JSON (returns_text=False)"
                 )
@@ -345,12 +403,25 @@ class TestEffectTypes:
             params={"lines": 100},
             user_id="user123",
             continuation=FormatSupervisorResponse(),
+            returns_text=True,
         )
         assert effect.method == "GET"
         assert effect.path == "/core/logs"
         assert effect.params == {"lines": 100}
         assert effect.user_id == "user123"
+        assert effect.returns_text is True
         assert isinstance(effect.continuation, FormatSupervisorResponse)
+
+    def test_supervisor_call_returns_text_defaults_false(self) -> None:
+        """returns_text defaults to False for JSON responses."""
+        effect = SupervisorCall(
+            method="GET",
+            path="/core/info",
+            params={},
+            user_id=None,
+            continuation=FormatSupervisorResponse(),
+        )
+        assert effect.returns_text is False
 
     def test_supervisor_call_frozen(self) -> None:
         """SupervisorCall is frozen."""


### PR DESCRIPTION
Closes #156.

## Summary

Addresses the four concrete bullets from the issue plus a fuller refresh of the static Supervisor endpoint list.

### 1. Log/text detection no longer relies on path heuristics

`http.py` previously inferred plain-text responses with `path.endswith(\"/logs\")`. That missed the newer log variants documented by the Supervisor (`/logs/follow`, `/logs/latest`, `/logs/boots/<bootid>`) and would have miscategorised `/addons/<slug>/changelog` and `/addons/<slug>/documentation`, which also return text.

Now `EndpointInfo.returns_text` (already the source of truth at definition time) is propagated through `SupervisorCall.returns_text` and into `EffectHandler.execute_supervisor_call(..., returns_text=...)`. The HTTP layer takes the flag verbatim.

### 2. GET query parameters reach the Supervisor

`hassio.send_command` accepts a `params` kwarg for query string arguments, but the call site passed only `payload`, silently dropping query params on GET requests (e.g. `lines` for log endpoints).

The call now routes parameters by method:

- write methods (`POST`/`PUT`/`PATCH`/`DELETE`) -> `payload=`
- read methods (everything else, primarily `GET`) -> `params=`

Never both at once.

### 3. \"App (add-on)\" terminology

HA 2026.6 rebranded add-ons to \"apps\" in user-facing surfaces but the REST paths still use `/addons`. Descriptions and slug schemas now read \"app (add-on)\" so search hits work for either term. Endpoint keys and API paths are unchanged.

### 4. Broader read-endpoint coverage

`SUPERVISOR_ENDPOINTS` grew from 12 to 52 read endpoints covering the current Supervisor surface: log variants, stats for every plugin, audio / cli / dns / multicast / observer / os, hardware, jobs, mounts, discovery, resolution, services, store, and per-interface network info.

## Out of scope

- No `/v2/apps` aliases or capability detection. The current Supervisor developer docs do not list any such route -- `/addons` is still the canonical path.
- No new write endpoints; the issue scoped this review to read endpoints.

## Tests

- Updated `test_effect_handler.py` to cover the new `returns_text` parameter, GET query-param forwarding, and the no-params GET case.
- Updated `test_supervisor_group.py` to assert `returns_text` propagation and tightened the bulk endpoint heuristics so they correctly distinguish text log endpoints from sibling JSON endpoints like `/host/logs/identifiers` and `/host/logs/boots`.
- Added a multi-source integration test that searching for either \"apps\" or \"add-on\" surfaces `/addons` endpoints, and that `SupervisorCall.returns_text` is set correctly end-to-end.
- Updated `test_aiohttp.py` mock handler to match the new keyword-only `returns_text` argument.

Full suite: `685 passed`. `ruff check`, `ruff format --check`, and `mypy` all clean.