### PR TITLE
Improve hass command schema guidance

### DIFF
--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -551,7 +551,51 @@ class TestExecuteHassCommandSchemaValidation:
         )
 
         assert result.success is False
-        assert "Validation error" in (result.error or "")
+        error = result.error or ""
+        assert "Validation error for hass/get_entity" in error
+        assert "required key not provided" in error
+        assert "entity_id" in error
+        assert "`arguments` must contain command-specific payload fields only" in error
+        assert "`id` or `type`" in error
+        assert (
+            'mcp__hamster__call(path="hass/get_entity", '
+            'arguments={"entity_id": "<string>"})'
+        ) in error
+
+    async def test_payload_command_injects_envelope_fields(
+        self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
+    ) -> None:
+        """Payload-only params succeed when HA schema requires id/type."""
+        captured_msg = None
+
+        def sync_handler(
+            hass: MagicMock, conn: InternalConnection, msg: dict[str, object]
+        ) -> None:
+            nonlocal captured_msg
+            captured_msg = msg
+            conn.send_result(msg["id"], {"ok": True})  # type: ignore[arg-type]
+
+        schema = vol.Schema(
+            {
+                vol.Required("id"): int,
+                vol.Required("type"): str,
+                vol.Required("entity_ids"): [str],
+            }
+        )
+        mock_hass.data = {"websocket_api": {"get_entries": (sync_handler, schema)}}
+
+        result = await effect_handler.execute_hass_command(
+            command_type="get_entries",
+            params={"entity_ids": ["light.living_room"]},
+            user_id=None,
+        )
+
+        assert result.success is True
+        assert result.data == {"ok": True}
+        assert captured_msg is not None
+        assert captured_msg["id"] == 1
+        assert captured_msg["type"] == "get_entries"
+        assert captured_msg["entity_ids"] == ["light.living_room"]
 
     async def test_schema_false_no_validation(
         self, effect_handler: HamsterEffectHandler, mock_hass: MagicMock
@@ -1186,6 +1230,28 @@ class TestRealHARegistry:
 
         assert result.success is False
         assert "extra keys not allowed" in (result.error or "")
+
+    async def test_entity_registry_get_entries_accepts_payload_only(
+        self,
+        hass_with_websocket_registry: HomeAssistant,
+        admin_user_id: str,
+    ) -> None:
+        """Real get_entries works with payload fields only."""
+        registry = hass_with_websocket_registry.data["websocket_api"]
+        command_type = "config/entity_registry/get_entries"
+        if command_type not in registry:
+            pytest.skip(f"{command_type} is not available in this HA version")
+
+        handler = HamsterEffectHandler(hass_with_websocket_registry)
+
+        result = await handler.execute_hass_command(
+            command_type=command_type,
+            params={"entity_ids": []},
+            user_id=admin_user_id,
+        )
+
+        assert result.success is True
+        assert isinstance(result.data, list)
 
     async def test_supported_features_filtered(
         self, hass_with_websocket_registry: HomeAssistant

--- a/src/hamster_mcp/component/http.py
+++ b/src/hamster_mcp/component/http.py
@@ -23,7 +23,11 @@ from homeassistant.exceptions import (
 )
 import voluptuous as vol
 
-from hamster_mcp.mcp._core.hass_group import _unpack_handler_entry
+from hamster_mcp.mcp._core.hass_group import (
+    _unpack_handler_entry,
+    format_hass_validation_error,
+    voluptuous_to_description,
+)
 from hamster_mcp.mcp._core.registry_enrichment import (
     AreaInfo,
     DeviceInfo,
@@ -46,6 +50,17 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _hass_validation_error(
+    command_type: str, schema: object, original_error: str
+) -> str:
+    """Format a hass validation error with command payload guidance."""
+    return format_hass_validation_error(
+        command_type,
+        original_error,
+        voluptuous_to_description(schema),
+    )
 
 
 def _orjson_default(obj: object) -> object:
@@ -392,7 +407,11 @@ class HamsterEffectHandler:
         if reserved_keys:
             return HassCommandResult(
                 success=False,
-                error=(f"Validation error: reserved keys not allowed: {reserved_keys}"),
+                error=_hass_validation_error(
+                    command_type,
+                    schema,
+                    f"reserved keys not allowed: {reserved_keys}",
+                ),
             )
 
         # Build message with required fields
@@ -406,14 +425,19 @@ class HamsterEffectHandler:
                 extra = sorted(set(msg) - {"id", "type"})
                 return HassCommandResult(
                     success=False,
-                    error=f"Validation error: extra keys not allowed: {extra}",
+                    error=_hass_validation_error(
+                        command_type,
+                        schema,
+                        f"extra keys not allowed: {extra}",
+                    ),
                 )
         else:
             try:
                 msg = schema(msg)
             except vol.Invalid as err:
                 return HassCommandResult(
-                    success=False, error=f"Validation error: {err}"
+                    success=False,
+                    error=_hass_validation_error(command_type, schema, str(err)),
                 )
 
         # Resolve user_id to User object for authorization checks. An unknown

--- a/src/hamster_mcp/mcp/_core/hass_group.py
+++ b/src/hamster_mcp/mcp/_core/hass_group.py
@@ -8,6 +8,7 @@ and command invocation.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import logging
 from typing import Any
 
@@ -15,6 +16,12 @@ from .events import Done, FormatHassResponse, HassCommand, ToolEffect
 from .types import CallToolResult, TextContent
 
 _LOGGER = logging.getLogger(__name__)
+
+_HASS_ENVELOPE_FIELDS: frozenset[str] = frozenset({"id", "type"})
+_FILTERED_COMMAND_REASON = (
+    "filtered because it is event/subscription/lifecycle behavior not supported "
+    "by the one-shot call tool"
+)
 
 
 # --- Types ---
@@ -63,10 +70,12 @@ def _get_voluptuous_type(validator: object) -> str:
             return "boolean"
         return "any"
 
-    # Handle All (chain of validators) - extract base type from first
+    # Handle All (chain of validators) - extract first recognizable type.
     if isinstance(validator, vol.All):
-        if validator.validators:
-            return _get_voluptuous_type(validator.validators[0])
+        for child_validator in validator.validators:
+            child_type = _get_voluptuous_type(child_validator)
+            if child_type != "any":
+                return child_type
         return "any"
 
     # Handle Any (union type)
@@ -99,6 +108,13 @@ def _get_voluptuous_type(validator: object) -> str:
     if validator is list or (
         isinstance(validator, type) and issubclass(validator, list)
     ):
+        return "array"
+
+    # Handle voluptuous-style nested/list validators like {"key": str}
+    # and [str].
+    if isinstance(validator, dict):
+        return "object"
+    if isinstance(validator, list):
         return "array"
 
     # Handle Schema (nested)
@@ -226,6 +242,8 @@ def voluptuous_to_description(schema: object) -> dict[str, object]:
         result = _extract_field_info(key, validator)
         if result:
             field_name, field_info = result
+            if field_name in _HASS_ENVELOPE_FIELDS:
+                continue
             fields[field_name] = field_info
 
     return {"fields": fields}
@@ -241,6 +259,96 @@ def _make_error(message: str) -> Done:
             content=(TextContent(text=message),),
             is_error=True,
         )
+    )
+
+
+def _format_filtered_command_message(path: str) -> str:
+    """Format the user-facing message for intentionally filtered commands."""
+    return f"Command not available: {path} ({_FILTERED_COMMAND_REASON})"
+
+
+def _user_field_items(
+    schema: dict[str, object],
+) -> tuple[tuple[str, dict[str, object]], ...]:
+    """Return user-supplied schema fields, excluding HA envelope fields."""
+    fields = schema.get("fields")
+    if not isinstance(fields, dict):
+        return ()
+
+    items: list[tuple[str, dict[str, object]]] = []
+    for field_name, field_info in fields.items():
+        if not isinstance(field_name, str):
+            continue
+        if field_name in _HASS_ENVELOPE_FIELDS:
+            continue
+        if not isinstance(field_info, dict):
+            continue
+        items.append((field_name, field_info))
+    return tuple(items)
+
+
+def _placeholder_for_type(field_type: object) -> object:
+    """Return a concise placeholder value for a schema type name."""
+    if field_type == "string":
+        return "<string>"
+    if field_type == "array":
+        return ["<value>"]
+    if field_type == "object":
+        return {"key": "<value>"}
+    if field_type == "boolean":
+        return True
+    if field_type in {"integer", "number"}:
+        return 0
+    return "<value>"
+
+
+def _required_example_arguments(schema: dict[str, object]) -> dict[str, object]:
+    """Build example arguments for required user-facing fields."""
+    example: dict[str, object] = {}
+    for field_name, field_info in _user_field_items(schema):
+        if field_info.get("required", False) is True:
+            example[field_name] = _placeholder_for_type(field_info.get("type"))
+    return example
+
+
+def _hass_path(command_type: str) -> str:
+    """Return a user-facing hass command path."""
+    if command_type.startswith("hass/"):
+        return command_type
+    return f"hass/{command_type}"
+
+
+def format_hass_call_example(
+    command_type: str, schema: dict[str, object] | None = None
+) -> str:
+    """Format an MCP call example for a hass command."""
+    arguments = _required_example_arguments(schema) if schema is not None else {}
+    return (
+        f'mcp__hamster__call(path="{_hass_path(command_type)}", '
+        f"arguments={json.dumps(arguments)})"
+    )
+
+
+def format_hass_usage_hint(command_type: str, schema: dict[str, object]) -> str | None:
+    """Format a short call example when a hass command has required fields."""
+    if not _required_example_arguments(schema):
+        return None
+    return f"Example: `{format_hass_call_example(command_type, schema)}`"
+
+
+def format_hass_validation_error(
+    command_type: str,
+    original_error: str,
+    schema: dict[str, object] | None = None,
+) -> str:
+    """Format hass validation errors with command-specific call guidance."""
+    command_path = _hass_path(command_type)
+    return (
+        f"Validation error for {command_path}: {original_error}\n\n"
+        "For `hass/` websocket commands, `arguments` must contain "
+        "command-specific payload fields only. Do not include websocket envelope "
+        "fields `id` or `type`; Hamster supplies them internally.\n\n"
+        f"Example: `{format_hass_call_example(command_type, schema)}`"
     )
 
 
@@ -321,9 +429,9 @@ class HassGroup:
                 search_parts.append(info.description)
             schema = info.schema
             if isinstance(schema, dict):
-                fields = schema.get("fields")
-                if isinstance(fields, dict):
-                    search_parts.extend(fields.keys())
+                search_parts.extend(
+                    field_name for field_name, _field_info in _user_field_items(schema)
+                )
             search_text = " ".join(search_parts).lower()
             entries.append((command_type, search_text, info))
 
@@ -410,6 +518,9 @@ class HassGroup:
         Returns:
             Formatted text with command details, or None if not found.
         """
+        if _is_filtered_command(path):
+            return _format_filtered_command_message(path)
+
         info = self._commands.get(path)
         if info is None:
             return None
@@ -424,14 +535,11 @@ class HassGroup:
         # Parameters
         schema = info.schema
         if isinstance(schema, dict):
-            fields = schema.get("fields")
-            if isinstance(fields, dict) and fields:
+            fields = _user_field_items(schema)
+            if fields:
                 lines.append("")
                 lines.append("### Parameters")
-                for field_name, field_info in fields.items():
-                    if not isinstance(field_info, dict):
-                        continue
-
+                for field_name, field_info in fields:
                     required = field_info.get("required", False)
                     field_type = field_info.get("type", "any")
                     desc = field_info.get("description")
@@ -450,6 +558,15 @@ class HassGroup:
                 lines.append("")
                 lines.append("No parameters required.")
 
+            hint = format_hass_usage_hint(path, schema)
+            if hint is not None:
+                lines.append("")
+                lines.append("### Usage")
+                lines.append(hint)
+        else:
+            lines.append("")
+            lines.append("No parameters required.")
+
         return "\n".join(lines)
 
     def schema(self, path: str) -> str | None:
@@ -461,6 +578,9 @@ class HassGroup:
         Returns:
             Formatted schema text, or None if not found.
         """
+        if _is_filtered_command(path):
+            return _format_filtered_command_message(path)
+
         info = self._commands.get(path)
         if info is None:
             return None
@@ -469,12 +589,9 @@ class HassGroup:
 
         schema = info.schema
         if isinstance(schema, dict):
-            fields = schema.get("fields")
-            if isinstance(fields, dict) and fields:
-                for field_name, field_info in fields.items():
-                    if not isinstance(field_info, dict):
-                        continue
-
+            fields = _user_field_items(schema)
+            if fields:
+                for field_name, field_info in fields:
                     required = field_info.get("required", False)
                     field_type = field_info.get("type", "any")
                     desc = field_info.get("description")
@@ -487,6 +604,12 @@ class HassGroup:
                         lines.append(f"  {desc}")
             else:
                 lines.append("No parameters required.")
+
+            hint = format_hass_usage_hint(path, schema)
+            if hint is not None:
+                lines.append("")
+                lines.append("### Usage")
+                lines.append(hint)
         else:
             lines.append("No parameters required.")
 
@@ -511,13 +634,13 @@ class HassGroup:
         Returns:
             HassCommand effect on success, Done with error otherwise.
         """
+        # Check if command is filtered
+        if _is_filtered_command(path):
+            return _make_error(_format_filtered_command_message(path))
+
         # Check if command exists
         if path not in self._commands:
             return _make_error(f"Command not found: {path}")
-
-        # Check if command is filtered
-        if _is_filtered_command(path):
-            return _make_error(f"Command not available: {path}")
 
         # Build the HassCommand effect
         return HassCommand(

--- a/src/hamster_mcp/mcp/_core/resources/insights/services-and-hass.md
+++ b/src/hamster_mcp/mcp/_core/resources/insights/services-and-hass.md
@@ -114,6 +114,24 @@ execution traces, and querying registries.  For example:
 See the *Reading Configurations* insight document for details on reading
 script and automation definitions.
 
+### WebSocket payloads
+
+For `hass/` WebSocket commands, put only command-specific payload fields in
+`arguments`. Do not include WebSocket envelope fields `id` or `type`; Hamster
+supplies those internally.
+
+For example, registry lookup payload fields go inside `arguments`:
+
+```json
+{
+  "path": "hass/config/entity_registry/get_entries",
+  "arguments": {"entity_ids": ["light.living_room"]}
+}
+```
+
+`hass/render_template` is intentionally not exposed because it produces
+subscription/event messages, which the one-shot call tool does not stream yet.
+
 ## Metadata Comparison
 
 | Capability | `services/` group | `hass/call_service` |

--- a/src/hamster_mcp/mcp/_tests/test_hass_group.py
+++ b/src/hamster_mcp/mcp/_tests/test_hass_group.py
@@ -194,6 +194,36 @@ class TestHassGroupExplain:
         result = group.explain("unknown")
         assert result is None
 
+    def test_explain_hides_envelope_fields_and_shows_usage(self) -> None:
+        """Explain hides id/type and shows payload-only usage."""
+        import voluptuous as vol
+
+        schema = vol.Schema(
+            {
+                vol.Required("id"): int,
+                vol.Required("type"): str,
+                vol.Required("entity_ids"): [str],
+            }
+        )
+        commands = {
+            "config/entity_registry/get_entries": CommandInfo(
+                command_type="config/entity_registry/get_entries",
+                schema=voluptuous_to_description(schema),
+            )
+        }
+        group = HassGroup.create(commands)
+
+        result = group.explain("config/entity_registry/get_entries")
+
+        assert result is not None
+        assert "entity_ids" in result
+        assert "- **id**" not in result
+        assert "- **type**" not in result
+        assert (
+            'mcp__hamster__call(path="hass/config/entity_registry/get_entries"'
+            in result
+        )
+
 
 class TestHassGroupSchema:
     """Tests for HassGroup.schema()."""
@@ -234,6 +264,33 @@ class TestHassGroupSchema:
         group = HassGroup.create({})
         result = group.schema("unknown")
         assert result is None
+
+    def test_schema_hides_envelope_fields_and_shows_usage(self) -> None:
+        """Schema hides id/type and shows payload-only usage."""
+        import voluptuous as vol
+
+        schema = vol.Schema(
+            {
+                vol.Required("id"): int,
+                vol.Required("type"): str,
+                vol.Required("entity_ids"): [str],
+            }
+        )
+        commands = {
+            "config/entity_registry/get_entries": CommandInfo(
+                command_type="config/entity_registry/get_entries",
+                schema=voluptuous_to_description(schema),
+            )
+        }
+        group = HassGroup.create(commands)
+
+        result = group.schema("config/entity_registry/get_entries")
+
+        assert result is not None
+        assert "- **entity_ids** (required) - type: array" in result
+        assert "- **id**" not in result
+        assert "- **type**" not in result
+        assert 'arguments={"entity_ids": ["<value>"]}' in result
 
 
 class TestHassGroupHasCommand:
@@ -339,6 +396,21 @@ class TestHassGroupParseCallArgs:
         assert isinstance(result, Done)
         assert result.result.is_error
         assert "not available" in result.result.content[0].text.lower()  # type: ignore[union-attr]
+
+    def test_filtered_render_template_error_even_when_not_discovered(self) -> None:
+        """Filtered commands report unavailable instead of not found."""
+        group = self._make_group()
+
+        result = group.parse_call_args(
+            "render_template", {"template": "{{ 1 }}"}, user_id=None
+        )
+
+        assert isinstance(result, Done)
+        assert result.result.is_error
+        text = result.result.content[0].text  # type: ignore[union-attr]
+        assert "Command not available: render_template" in text
+        assert "filtered because" in text
+        assert "not found" not in text.lower()
 
 
 class TestCommandFiltering:
@@ -505,6 +577,32 @@ class TestVoluptuousConversion:
         assert isinstance(field, dict)
         assert field["required"] is True
         assert field["type"] == "string"
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("voluptuous", reason="voluptuous not installed"),
+        reason="voluptuous not installed",
+    )
+    def test_excludes_hass_envelope_fields(self) -> None:
+        """voluptuous_to_description excludes id and type envelope fields."""
+        import voluptuous as vol
+
+        schema = vol.Schema(
+            {
+                vol.Required("id"): int,
+                vol.Required("type"): str,
+                vol.Required("entity_ids"): [str],
+            }
+        )
+
+        result = voluptuous_to_description(schema)
+
+        fields = result["fields"]
+        assert isinstance(fields, dict)
+        assert set(fields) == {"entity_ids"}
+        field = fields["entity_ids"]
+        assert isinstance(field, dict)
+        assert field["required"] is True
+        assert field["type"] == "array"
 
     @pytest.mark.skipif(
         not pytest.importorskip("voluptuous", reason="voluptuous not installed"),

--- a/src/hamster_mcp/mcp/_tests/test_hass_group.py
+++ b/src/hamster_mcp/mcp/_tests/test_hass_group.py
@@ -196,7 +196,7 @@ class TestHassGroupExplain:
 
     def test_explain_hides_envelope_fields_and_shows_usage(self) -> None:
         """Explain hides id/type and shows payload-only usage."""
-        import voluptuous as vol
+        vol = pytest.importorskip("voluptuous", reason="voluptuous not installed")
 
         schema = vol.Schema(
             {
@@ -267,7 +267,7 @@ class TestHassGroupSchema:
 
     def test_schema_hides_envelope_fields_and_shows_usage(self) -> None:
         """Schema hides id/type and shows payload-only usage."""
-        import voluptuous as vol
+        vol = pytest.importorskip("voluptuous", reason="voluptuous not installed")
 
         schema = vol.Schema(
             {


### PR DESCRIPTION
## Summary

- Hide Home Assistant websocket envelope fields `id` and `type` from user-facing `hass/` schemas and explanations.
- Add concise payload-only `mcp__hamster__call(...)` usage hints for hass commands with required fields.
- Improve hass validation errors with command path, original HA validation text, payload-only guidance, and examples.
- Clarify filtered command diagnostics for event/subscription/lifecycle commands like `render_template`.
- Document hass websocket payload guidance and the current `render_template` streaming limitation.

## Tests

- `mise exec -- pytest src/hamster_mcp/mcp/_tests/test_hass_group.py src/hamster_mcp/component/_tests/test_hass_effects.py`
- `mise exec -- ruff format --check .`
- `mise exec -- ruff check .`
- `mise exec -- mypy`
- `mise exec -- pytest src/`

## Notes

`hass/render_template` remains intentionally unavailable until Hamster supports streaming/subscription effects.
