### PR TITLE
Expose blocked hass commands in discovery

### DIFF
--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -1256,13 +1256,8 @@ class TestRealHARegistry:
     async def test_supported_features_filtered(
         self, hass_with_websocket_registry: HomeAssistant
     ) -> None:
-        """supported_features is filtered out at the HassGroup layer.
-
-        Direct invocation via ``execute_hass_command`` would still try to
-        call ``set_supported_features`` on the InternalConnection (which we
-        now support), but the user-facing surface (HassGroup.has_command)
-        rejects it so it cannot be reached from MCP.
-        """
+        """Blocked real commands are discoverable but not callable."""
+        from hamster_mcp.mcp._core.events import Done, HassCommand
         from hamster_mcp.mcp._core.hass_group import (
             HassGroup,
             discover_commands,
@@ -1272,11 +1267,26 @@ class TestRealHARegistry:
         commands = discover_commands(registry)
         group = HassGroup.create(commands)
 
-        assert group.has_command("supported_features") is False
-        assert group.has_command("render_template") is False
-        assert group.has_command("fire_event") is False
+        blocked_commands = ["supported_features", "render_template"]
+        if "fire_event" in registry:
+            blocked_commands.append("fire_event")
+
+        for command_type in blocked_commands:
+            assert command_type in registry
+            assert group.has_command(command_type) is True
+
+            effect = group.parse_call_args(command_type, {}, user_id=None)
+
+            assert isinstance(effect, Done)
+            assert effect.result.is_error is True
+            error_text = effect.result.content[0].text  # type: ignore[union-attr]
+            assert "Command not available" in error_text
+            assert command_type in error_text
+
         # Sanity: a normal command is still available.
         assert group.has_command("get_states") is True
+        effect = group.parse_call_args("get_states", {}, user_id=None)
+        assert isinstance(effect, HassCommand)
 
     async def test_unknown_user_rejected_against_real_registry(
         self, hass_with_websocket_registry: HomeAssistant

--- a/src/hamster_mcp/component/_tests/test_multi_source_integration.py
+++ b/src/hamster_mcp/component/_tests/test_multi_source_integration.py
@@ -161,6 +161,7 @@ class TestHassGroupFlow:
             "get_states": (mock_handler, False),
             "config/entity_registry/list": (mock_handler, False),
             "lovelace/resources": (mock_handler, False),
+            "subscribe_events": (mock_handler, False),
         }
 
         with patch(
@@ -179,6 +180,10 @@ class TestHassGroupFlow:
 
         result = hass_group.search("registry")
         assert "config/entity_registry/list" in result
+
+        blocked_result = hass_group.search("subscribe")
+        assert "subscribe_events" in blocked_result
+        assert "unavailable" in blocked_result.lower()
 
     async def test_explain_hass_command(
         self,
@@ -241,6 +246,42 @@ class TestHassGroupFlow:
         assert isinstance(effect, HassCommand)
         assert effect.command_type == "get_states"
         assert effect.user_id == "test_user"
+
+    async def test_blocked_hass_command_is_discoverable_but_not_callable(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Blocked hass commands appear in docs surfaces but calls fail."""
+        from hamster_mcp.mcp._core.events import Done
+
+        mock_handler = MagicMock()
+        hass.data["websocket_api"] = {
+            "subscribe_events": (mock_handler, False),
+        }
+
+        with patch(
+            "hamster_mcp.component.async_get_all_descriptions",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        runtime = mock_config_entry.runtime_data
+        manager = runtime.manager
+
+        hass_group = manager._registry.get("hass")
+        assert hass_group is not None
+        assert hass_group.has_command("subscribe_events") is True
+
+        explain = hass_group.explain("subscribe_events")
+        assert explain is not None
+        assert "Unavailable" in explain
+
+        effect = hass_group.parse_call_args("subscribe_events", {}, user_id="test_user")
+        assert isinstance(effect, Done)
+        assert effect.result.is_error is True
 
 
 class TestSupervisorGroupFlow:

--- a/src/hamster_mcp/component/_tests/test_multi_source_integration.py
+++ b/src/hamster_mcp/component/_tests/test_multi_source_integration.py
@@ -282,6 +282,9 @@ class TestHassGroupFlow:
         effect = hass_group.parse_call_args("subscribe_events", {}, user_id="test_user")
         assert isinstance(effect, Done)
         assert effect.result.is_error is True
+        error_text = effect.result.content[0].text  # type: ignore[union-attr]
+        assert "Command not available" in error_text
+        assert "subscribe_events" in error_text
 
 
 class TestSupervisorGroupFlow:

--- a/src/hamster_mcp/mcp/_core/docs_enrichment.py
+++ b/src/hamster_mcp/mcp/_core/docs_enrichment.py
@@ -109,6 +109,7 @@ def enrich_commands(
                 command_type=info.command_type,
                 schema=info.schema,
                 description=desc,
+                blocked_reason=info.blocked_reason,
             )
         else:
             enriched[cmd_type] = info

--- a/src/hamster_mcp/mcp/_core/hass_group.py
+++ b/src/hamster_mcp/mcp/_core/hass_group.py
@@ -35,11 +35,13 @@ class CommandInfo:
         command_type: The command type string (e.g., "get_states")
         schema: JSON-representable schema description
         description: Human-readable description (None until docs enrichment)
+        blocked_reason: Why the command is unavailable for calls, if blocked
     """
 
     command_type: str
     schema: dict[str, object]
     description: str | None = None
+    blocked_reason: str | None = None
 
 
 # --- Voluptuous schema conversion ---
@@ -262,9 +264,21 @@ def _make_error(message: str) -> Done:
     )
 
 
-def _format_filtered_command_message(path: str) -> str:
-    """Format the user-facing message for intentionally filtered commands."""
-    return f"Command not available: {path} ({_FILTERED_COMMAND_REASON})"
+def _filtered_command_reason(command_type: str) -> str | None:
+    """Return the unavailable reason for filtered commands, if filtered."""
+    if _is_filtered_command(command_type):
+        return _FILTERED_COMMAND_REASON
+    return None
+
+
+def _format_blocked_command_message(path: str, reason: str) -> str:
+    """Format the user-facing message for intentionally blocked commands."""
+    return f"Command not available: {path} ({reason})"
+
+
+def _format_blocked_command_details(path: str, reason: str) -> str:
+    """Format detailed unavailable command information."""
+    return "\n".join([f"## {path}", "", "Unavailable.", "", f"Reason: {reason}"])
 
 
 def _user_field_items(
@@ -502,10 +516,13 @@ class HassGroup:
 
         lines = [header, ""]
         for i, (cmd_type, info) in enumerate(matches, 1):
+            availability = " (unavailable)" if info.blocked_reason is not None else ""
             if info.description:
-                lines.append(f"{i}. **{cmd_type}** - {info.description}")
+                lines.append(f"{i}. **{cmd_type}**{availability} - {info.description}")
             else:
-                lines.append(f"{i}. **{cmd_type}**")
+                lines.append(f"{i}. **{cmd_type}**{availability}")
+            if info.blocked_reason is not None:
+                lines.append(f"   Unavailable: {info.blocked_reason}")
 
         return "\n".join(lines)
 
@@ -518,12 +535,12 @@ class HassGroup:
         Returns:
             Formatted text with command details, or None if not found.
         """
-        if _is_filtered_command(path):
-            return _format_filtered_command_message(path)
-
         info = self._commands.get(path)
         if info is None:
             return None
+
+        if info.blocked_reason is not None:
+            return _format_blocked_command_details(path, info.blocked_reason)
 
         lines = [f"## {path}"]
 
@@ -578,12 +595,12 @@ class HassGroup:
         Returns:
             Formatted schema text, or None if not found.
         """
-        if _is_filtered_command(path):
-            return _format_filtered_command_message(path)
-
         info = self._commands.get(path)
         if info is None:
             return None
+
+        if info.blocked_reason is not None:
+            return _format_blocked_command_details(path, info.blocked_reason)
 
         lines = [f"## {path} Parameters", ""]
 
@@ -616,9 +633,7 @@ class HassGroup:
         return "\n".join(lines)
 
     def has_command(self, path: str) -> bool:
-        """Check if a command exists (and is not filtered)."""
-        if _is_filtered_command(path):
-            return False
+        """Check if a command was discovered."""
         return path in self._commands
 
     def parse_call_args(
@@ -634,13 +649,19 @@ class HassGroup:
         Returns:
             HassCommand effect on success, Done with error otherwise.
         """
-        # Check if command is filtered
-        if _is_filtered_command(path):
-            return _make_error(_format_filtered_command_message(path))
-
         # Check if command exists
-        if path not in self._commands:
+        info = self._commands.get(path)
+        if info is None:
+            filtered_reason = _filtered_command_reason(path)
+            if filtered_reason is not None:
+                return _make_error(
+                    _format_blocked_command_message(path, filtered_reason)
+                )
             return _make_error(f"Command not found: {path}")
+
+        blocked_reason = info.blocked_reason or _filtered_command_reason(path)
+        if blocked_reason is not None:
+            return _make_error(_format_blocked_command_message(path, blocked_reason))
 
         # Build the HassCommand effect
         return HassCommand(
@@ -668,10 +689,6 @@ def discover_commands(
     commands: dict[str, CommandInfo] = {}
 
     for command_type, entry in websocket_api_registry.items():
-        # Filter out subscription and auth commands
-        if _is_filtered_command(command_type):
-            continue
-
         # Guard against HA internal registry shape drift. The current shape
         # is ``(handler, schema_or_False)`` but this is private HA state, so
         # we defensively skip entries that no longer match.
@@ -687,11 +704,13 @@ def discover_commands(
 
         # Convert schema
         schema_desc = voluptuous_to_description(schema)
+        blocked_reason = _filtered_command_reason(command_type)
 
         commands[command_type] = CommandInfo(
             command_type=command_type,
             schema=schema_desc,
             description=None,  # No description until docs enrichment
+            blocked_reason=blocked_reason,
         )
 
     return commands

--- a/src/hamster_mcp/mcp/_tests/test_docs_enrichment.py
+++ b/src/hamster_mcp/mcp/_tests/test_docs_enrichment.py
@@ -420,6 +420,24 @@ class TestEnrichCommands:
         assert result["call_service"].schema == schema
         assert result["call_service"].description == "Call a service."
 
+    def test_preserves_blocked_reason(self) -> None:
+        commands = {
+            "subscribe_events": CommandInfo(
+                command_type="subscribe_events",
+                schema={"fields": {}},
+                blocked_reason="subscription commands are unavailable",
+            ),
+        }
+        descriptions = {"subscribe_events": "Subscribe to events."}
+
+        result = enrich_commands(commands, descriptions)
+
+        assert result["subscribe_events"].description == "Subscribe to events."
+        assert (
+            result["subscribe_events"].blocked_reason
+            == "subscription commands are unavailable"
+        )
+
     def test_overwrites_existing_description(self) -> None:
         commands = {
             "get_states": CommandInfo(

--- a/src/hamster_mcp/mcp/_tests/test_hass_group.py
+++ b/src/hamster_mcp/mcp/_tests/test_hass_group.py
@@ -79,6 +79,12 @@ class TestHassGroupSearch:
                 schema={"fields": {"domain": {"required": True, "type": "string"}}},
                 description="Call a Home Assistant service",
             ),
+            "subscribe_events": CommandInfo(
+                command_type="subscribe_events",
+                schema={"fields": {}},
+                description="Subscribe to events",
+                blocked_reason="subscription commands are unavailable",
+            ),
         }
         return HassGroup.create(commands)
 
@@ -122,6 +128,14 @@ class TestHassGroupSearch:
         result = group.search("nonexistent", path_filter="config")
         assert 'No commands found matching "nonexistent"' in result
         assert "config" in result
+
+    def test_search_marks_blocked_commands_unavailable(self) -> None:
+        """Search includes blocked commands but marks them unavailable."""
+        group = self._make_group()
+        result = group.search("subscribe")
+        assert "subscribe_events" in result
+        assert "unavailable" in result.lower()
+        assert "subscription commands are unavailable" in result
 
 
 class TestHassGroupExplain:
@@ -194,6 +208,25 @@ class TestHassGroupExplain:
         result = group.explain("unknown")
         assert result is None
 
+    def test_explain_blocked_command(self) -> None:
+        """Explain surfaces blocked commands as unavailable."""
+        group = HassGroup.create(
+            {
+                "subscribe_events": CommandInfo(
+                    command_type="subscribe_events",
+                    schema={"fields": {}},
+                    blocked_reason="subscription commands are unavailable",
+                )
+            }
+        )
+
+        result = group.explain("subscribe_events")
+
+        assert result is not None
+        assert "subscribe_events" in result
+        assert "Unavailable" in result
+        assert "subscription commands are unavailable" in result
+
     def test_explain_hides_envelope_fields_and_shows_usage(self) -> None:
         """Explain hides id/type and shows payload-only usage."""
         vol = pytest.importorskip("voluptuous", reason="voluptuous not installed")
@@ -265,6 +298,25 @@ class TestHassGroupSchema:
         result = group.schema("unknown")
         assert result is None
 
+    def test_schema_blocked_command(self) -> None:
+        """Schema surfaces blocked commands as unavailable."""
+        group = HassGroup.create(
+            {
+                "subscribe_events": CommandInfo(
+                    command_type="subscribe_events",
+                    schema={"fields": {}},
+                    blocked_reason="subscription commands are unavailable",
+                )
+            }
+        )
+
+        result = group.schema("subscribe_events")
+
+        assert result is not None
+        assert "subscribe_events" in result
+        assert "Unavailable" in result
+        assert "subscription commands are unavailable" in result
+
     def test_schema_hides_envelope_fields_and_shows_usage(self) -> None:
         """Schema hides id/type and shows payload-only usage."""
         vol = pytest.importorskip("voluptuous", reason="voluptuous not installed")
@@ -321,15 +373,14 @@ class TestHassGroupHasCommand:
         assert group.has_command("get_states") is True
 
     def test_subscribe_filtered(self) -> None:
-        """has_command returns False for subscribe commands."""
+        """has_command returns True for discovered subscribe commands."""
         group = self._make_group_with_filtered()
-        # Even though it's in the dict, it's filtered
-        assert group.has_command("subscribe_events") is False
+        assert group.has_command("subscribe_events") is True
 
     def test_auth_filtered(self) -> None:
-        """has_command returns False for auth commands."""
+        """has_command returns True for discovered auth commands."""
         group = self._make_group_with_filtered()
-        assert group.has_command("auth") is False
+        assert group.has_command("auth") is True
 
     def test_unknown_command(self) -> None:
         """has_command returns False for unknown command."""
@@ -768,18 +819,20 @@ class TestDiscoverCommands:
         result = discover_commands({})
         assert result == {}
 
-    def test_filters_subscribe(self) -> None:
-        """Subscribe commands are filtered out."""
+    def test_marks_subscribe_blocked(self) -> None:
+        """Subscribe commands are discovered but marked blocked."""
         registry = {
             "get_states": (lambda: None, False),
             "subscribe_events": (lambda: None, False),
         }
         result = discover_commands(registry)
         assert "get_states" in result
-        assert "subscribe_events" not in result
+        assert "subscribe_events" in result
+        assert result["get_states"].blocked_reason is None
+        assert result["subscribe_events"].blocked_reason is not None
 
-    def test_filters_auth(self) -> None:
-        """Auth commands are filtered out."""
+    def test_marks_auth_blocked(self) -> None:
+        """Auth commands are discovered but marked blocked."""
         registry = {
             "get_states": (lambda: None, False),
             "auth": (lambda: None, False),
@@ -787,8 +840,10 @@ class TestDiscoverCommands:
         }
         result = discover_commands(registry)
         assert "get_states" in result
-        assert "auth" not in result
-        assert "auth/sign_path" not in result
+        assert "auth" in result
+        assert "auth/sign_path" in result
+        assert result["auth"].blocked_reason is not None
+        assert result["auth/sign_path"].blocked_reason is not None
 
     def test_schema_false_handled(self) -> None:
         """Commands with schema=False have empty fields."""


### PR DESCRIPTION
Closes #173.

## Summary

- Keep filtered Home Assistant websocket commands in discovery with a `blocked_reason` marker.
- Surface blocked commands in `search`, `explain`, and `schema` as unavailable instead of treating them as unknown.
- Preserve blocked metadata during docs enrichment and keep `parse_call_args()` rejecting unavailable commands.
- Update unit and integration coverage for blocked command discovery, docs surfaces, and call rejection.

## Verification

- `mise exec -- ruff format --check .`
- `mise exec -- ruff check .`
- `mise exec -- pytest src/hamster_mcp/mcp/_tests/test_hass_group.py`
- `mise exec -- pytest src/hamster_mcp/mcp/_tests/test_docs_enrichment.py`
- `mise exec -- pytest src/hamster_mcp/component/_tests/test_multi_source_integration.py`

Note: the planned `mise run pytest ...` commands failed because this repository does not define a `pytest` mise task, so the same tests were run with `mise exec -- pytest ...` per repo environment guidance.
