### PR TITLE
Clarify blocked hass command wording

### DIFF
--- a/src/hamster_mcp/component/_tests/test_hass_effects.py
+++ b/src/hamster_mcp/component/_tests/test_hass_effects.py
@@ -1280,8 +1280,10 @@ class TestRealHARegistry:
             assert isinstance(effect, Done)
             assert effect.result.is_error is True
             error_text = effect.result.content[0].text  # type: ignore[union-attr]
-            assert "Command not available" in error_text
-            assert command_type in error_text
+            assert (
+                f"Command intentionally unavailable: hass/{command_type}" in error_text
+            )
+            assert "Reason:" in error_text
 
         # Sanity: a normal command is still available.
         assert group.has_command("get_states") is True

--- a/src/hamster_mcp/component/_tests/test_multi_source_integration.py
+++ b/src/hamster_mcp/component/_tests/test_multi_source_integration.py
@@ -277,14 +277,15 @@ class TestHassGroupFlow:
 
         explain = hass_group.explain("subscribe_events")
         assert explain is not None
-        assert "Unavailable" in explain
+        assert "Command intentionally unavailable" in explain
+        assert "hass/subscribe_events" in explain
 
         effect = hass_group.parse_call_args("subscribe_events", {}, user_id="test_user")
         assert isinstance(effect, Done)
         assert effect.result.is_error is True
         error_text = effect.result.content[0].text  # type: ignore[union-attr]
-        assert "Command not available" in error_text
-        assert "subscribe_events" in error_text
+        assert "Command intentionally unavailable: hass/subscribe_events" in error_text
+        assert "Reason:" in error_text
 
 
 class TestSupervisorGroupFlow:

--- a/src/hamster_mcp/mcp/_core/hass_group.py
+++ b/src/hamster_mcp/mcp/_core/hass_group.py
@@ -273,12 +273,22 @@ def _filtered_command_reason(command_type: str) -> str | None:
 
 def _format_blocked_command_message(path: str, reason: str) -> str:
     """Format the user-facing message for intentionally blocked commands."""
-    return f"Command not available: {path} ({reason})"
+    command_path = _hass_path(path)
+    return f"Command intentionally unavailable: {command_path}\nReason: {reason}"
 
 
 def _format_blocked_command_details(path: str, reason: str) -> str:
     """Format detailed unavailable command information."""
-    return "\n".join([f"## {path}", "", "Unavailable.", "", f"Reason: {reason}"])
+    command_path = _hass_path(path)
+    return "\n".join(
+        [
+            f"## {command_path}",
+            "",
+            "Command intentionally unavailable.",
+            "",
+            f"Reason: {reason}",
+        ]
+    )
 
 
 def _user_field_items(
@@ -516,13 +526,18 @@ class HassGroup:
 
         lines = [header, ""]
         for i, (cmd_type, info) in enumerate(matches, 1):
-            availability = " (unavailable)" if info.blocked_reason is not None else ""
+            availability = (
+                " (intentionally unavailable)"
+                if info.blocked_reason is not None
+                else ""
+            )
             if info.description:
                 lines.append(f"{i}. **{cmd_type}**{availability} - {info.description}")
             else:
                 lines.append(f"{i}. **{cmd_type}**{availability}")
             if info.blocked_reason is not None:
-                lines.append(f"   Unavailable: {info.blocked_reason}")
+                lines.append(f"   Command path: `{_hass_path(cmd_type)}`")
+                lines.append(f"   Reason: {info.blocked_reason}")
 
         return "\n".join(lines)
 

--- a/src/hamster_mcp/mcp/_tests/test_hass_group.py
+++ b/src/hamster_mcp/mcp/_tests/test_hass_group.py
@@ -134,7 +134,8 @@ class TestHassGroupSearch:
         group = self._make_group()
         result = group.search("subscribe")
         assert "subscribe_events" in result
-        assert "unavailable" in result.lower()
+        assert "intentionally unavailable" in result
+        assert "hass/subscribe_events" in result
         assert "subscription commands are unavailable" in result
 
 
@@ -223,8 +224,8 @@ class TestHassGroupExplain:
         result = group.explain("subscribe_events")
 
         assert result is not None
-        assert "subscribe_events" in result
-        assert "Unavailable" in result
+        assert "hass/subscribe_events" in result
+        assert "Command intentionally unavailable" in result
         assert "subscription commands are unavailable" in result
 
     def test_explain_hides_envelope_fields_and_shows_usage(self) -> None:
@@ -313,8 +314,8 @@ class TestHassGroupSchema:
         result = group.schema("subscribe_events")
 
         assert result is not None
-        assert "subscribe_events" in result
-        assert "Unavailable" in result
+        assert "hass/subscribe_events" in result
+        assert "Command intentionally unavailable" in result
         assert "subscription commands are unavailable" in result
 
     def test_schema_hides_envelope_fields_and_shows_usage(self) -> None:
@@ -438,7 +439,9 @@ class TestHassGroupParseCallArgs:
         result = group.parse_call_args("unknown", {}, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
-        assert "not found" in result.result.content[0].text.lower()  # type: ignore[union-attr]
+        text = result.result.content[0].text  # type: ignore[union-attr]
+        assert text == "Command not found: unknown"
+        assert "intentionally unavailable" not in text
 
     def test_filtered_command_error(self) -> None:
         """Filtered command returns error."""
@@ -446,7 +449,9 @@ class TestHassGroupParseCallArgs:
         result = group.parse_call_args("subscribe_events", {}, user_id=None)
         assert isinstance(result, Done)
         assert result.result.is_error
-        assert "not available" in result.result.content[0].text.lower()  # type: ignore[union-attr]
+        text = result.result.content[0].text  # type: ignore[union-attr]
+        assert "Command intentionally unavailable: hass/subscribe_events" in text
+        assert "filtered because" in text
 
     def test_filtered_render_template_error_even_when_not_discovered(self) -> None:
         """Filtered commands report unavailable instead of not found."""
@@ -459,7 +464,7 @@ class TestHassGroupParseCallArgs:
         assert isinstance(result, Done)
         assert result.result.is_error
         text = result.result.content[0].text  # type: ignore[union-attr]
-        assert "Command not available: render_template" in text
+        assert "Command intentionally unavailable: hass/render_template" in text
         assert "filtered because" in text
         assert "not found" not in text.lower()
 

--- a/src/hamster_mcp/mcp/_tests/test_hass_group.py
+++ b/src/hamster_mcp/mcp/_tests/test_hass_group.py
@@ -135,8 +135,8 @@ class TestHassGroupSearch:
         result = group.search("subscribe")
         assert "subscribe_events" in result
         assert "intentionally unavailable" in result
-        assert "hass/subscribe_events" in result
-        assert "subscription commands are unavailable" in result
+        assert "Command path: `hass/subscribe_events`" in result
+        assert "Reason: subscription commands are unavailable" in result
 
 
 class TestHassGroupExplain:
@@ -223,10 +223,13 @@ class TestHassGroupExplain:
 
         result = group.explain("subscribe_events")
 
-        assert result is not None
-        assert "hass/subscribe_events" in result
-        assert "Command intentionally unavailable" in result
-        assert "subscription commands are unavailable" in result
+        assert result == (
+            "## hass/subscribe_events\n"
+            "\n"
+            "Command intentionally unavailable.\n"
+            "\n"
+            "Reason: subscription commands are unavailable"
+        )
 
     def test_explain_hides_envelope_fields_and_shows_usage(self) -> None:
         """Explain hides id/type and shows payload-only usage."""
@@ -313,10 +316,13 @@ class TestHassGroupSchema:
 
         result = group.schema("subscribe_events")
 
-        assert result is not None
-        assert "hass/subscribe_events" in result
-        assert "Command intentionally unavailable" in result
-        assert "subscription commands are unavailable" in result
+        assert result == (
+            "## hass/subscribe_events\n"
+            "\n"
+            "Command intentionally unavailable.\n"
+            "\n"
+            "Reason: subscription commands are unavailable"
+        )
 
     def test_schema_hides_envelope_fields_and_shows_usage(self) -> None:
         """Schema hides id/type and shows payload-only usage."""
@@ -450,8 +456,11 @@ class TestHassGroupParseCallArgs:
         assert isinstance(result, Done)
         assert result.result.is_error
         text = result.result.content[0].text  # type: ignore[union-attr]
-        assert "Command intentionally unavailable: hass/subscribe_events" in text
-        assert "filtered because" in text
+        assert text == (
+            "Command intentionally unavailable: hass/subscribe_events\n"
+            "Reason: filtered because it is event/subscription/lifecycle behavior "
+            "not supported by the one-shot call tool"
+        )
 
     def test_filtered_render_template_error_even_when_not_discovered(self) -> None:
         """Filtered commands report unavailable instead of not found."""
@@ -464,8 +473,11 @@ class TestHassGroupParseCallArgs:
         assert isinstance(result, Done)
         assert result.result.is_error
         text = result.result.content[0].text  # type: ignore[union-attr]
-        assert "Command intentionally unavailable: hass/render_template" in text
-        assert "filtered because" in text
+        assert text == (
+            "Command intentionally unavailable: hass/render_template\n"
+            "Reason: filtered because it is event/subscription/lifecycle behavior "
+            "not supported by the one-shot call tool"
+        )
         assert "not found" not in text.lower()
 
 


### PR DESCRIPTION
## Summary

- Clarifies blocked `hass/` WebSocket command wording across search, explain, schema, and call errors.
- Uses the consistent phrase “Command intentionally unavailable” with the full `hass/...` command path and reason.
- Keeps unknown commands distinct as `Command not found`.

Fixes #174

## Verification

- `mise exec -- ruff format --check .`
- `mise exec -- ruff check .`
- `mise exec -- pytest src/hamster_mcp/mcp/_tests/test_hass_group.py`
- `mise exec -- pytest src/hamster_mcp/component/_tests/test_multi_source_integration.py src/hamster_mcp/component/_tests/test_hass_effects.py`
- Pre-commit hooks during signed commit, including `mypy`
