### PR TITLE
Sanitize websocket docs examples

### DIFF
--- a/src/hamster_mcp/mcp/_core/docs_enrichment.py
+++ b/src/hamster_mcp/mcp/_core/docs_enrichment.py
@@ -31,6 +31,7 @@ _EXCLUDED_TYPES: frozenset[str] = frozenset(
 )
 
 _CODE_BLOCK_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n```", re.DOTALL)
+_BLANK_LINES_RE = re.compile(r"\n{3,}")
 _COMMENT_RE = re.compile(r"//[^\n]*")
 _H2_RE = re.compile(r"^## (.+)$", re.MULTILINE)
 _H3_RE = re.compile(r"^### (.+)$", re.MULTILINE)
@@ -58,22 +59,23 @@ def parse_websocket_docs(markdown: str) -> dict[str, str]:
 
         if not subsections:
             # No ### subsections — whole body is the description.
-            description = body.strip()
+            description = _sanitize_description(body)
             if not description:
                 continue
             for cmd_type in _extract_command_types(body):
                 if cmd_type not in _EXCLUDED_TYPES and cmd_type not in result:
                     result[cmd_type] = description
         else:
+            parent_description = _sanitize_description(preamble)
             # Assign preamble commands the preamble text.
-            if preamble:
+            if parent_description:
                 for cmd_type in _extract_command_types(preamble):
                     if cmd_type not in _EXCLUDED_TYPES and cmd_type not in result:
-                        result[cmd_type] = preamble
+                        result[cmd_type] = parent_description
 
             # Assign subsection commands their subsection text.
             for _sub_heading, sub_body in subsections:
-                sub_desc = sub_body.strip()
+                sub_desc = _sanitize_description(sub_body) or parent_description
                 if not sub_desc:
                     continue
                 for cmd_type in _extract_command_types(sub_body):
@@ -192,8 +194,36 @@ def _extract_command_types(text: str) -> list[str]:
     return command_types
 
 
+def _sanitize_description(text: str) -> str:
+    """Remove raw HA WebSocket payload examples from docs descriptions.
+
+    Command types are extracted from the original markdown, but enriched MCP
+    descriptions should not retain examples that show Home Assistant's raw
+    WebSocket ``id``/``type`` envelope instead of Hamster's ``path`` and
+    ``arguments`` interface.
+    """
+    return _BLANK_LINES_RE.sub(
+        "\n\n", _CODE_BLOCK_RE.sub(_sanitize_code_block, text)
+    ).strip()
+
+
+def _sanitize_code_block(match: re.Match[str]) -> str:
+    block = match.group(1)
+    if (
+        _top_level_type_from_json(block) is not None
+        or _type_from_regex(block) is not None
+    ):
+        return ""
+    return match.group(0)
+
+
 def _type_from_json(block: str) -> str | None:
     """Try to extract ``"type"`` by parsing the block as JSON."""
+    return _top_level_type_from_json(block)
+
+
+def _top_level_type_from_json(block: str) -> str | None:
+    """Try to extract a top-level ``"type"`` field by parsing JSON."""
     stripped = _COMMENT_RE.sub("", block)
     try:
         data = json.loads(stripped)

--- a/src/hamster_mcp/mcp/_core/docs_enrichment.py
+++ b/src/hamster_mcp/mcp/_core/docs_enrichment.py
@@ -210,7 +210,7 @@ def _sanitize_description(text: str) -> str:
 def _sanitize_code_block(match: re.Match[str]) -> str:
     block = match.group(1)
     if (
-        _top_level_type_from_json(block) is not None
+        _payload_envelope_type_from_json(block) is not None
         or _type_from_regex(block) is not None
     ):
         return ""
@@ -231,6 +231,21 @@ def _top_level_type_from_json(block: str) -> str | None:
         return None
 
     if not isinstance(data, dict):
+        return None
+
+    cmd_type = data.get("type")
+    return cmd_type if isinstance(cmd_type, str) else None
+
+
+def _payload_envelope_type_from_json(block: str) -> str | None:
+    """Try to extract ``"type"`` from a raw HA WebSocket payload envelope."""
+    stripped = _COMMENT_RE.sub("", block)
+    try:
+        data = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not isinstance(data, dict) or "id" not in data:
         return None
 
     cmd_type = data.get("type")

--- a/src/hamster_mcp/mcp/_tests/test_docs_enrichment.py
+++ b/src/hamster_mcp/mcp/_tests/test_docs_enrichment.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from hamster_mcp.mcp._core.docs_enrichment import (
     _extract_command_types,
+    _sanitize_description,
     _split_h2_sections,
     _split_h3_subsections,
     _type_from_json,
@@ -235,6 +236,35 @@ class TestExtractCommandTypes:
 
     def test_no_code_blocks(self) -> None:
         assert _extract_command_types("Just text, no code blocks.") == []
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_description
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeDescription:
+    """Tests for _sanitize_description."""
+
+    def test_removes_raw_payload_envelope_code_block(self) -> None:
+        text = (
+            "Before.\n\n"
+            '```json\n{\n  "id": 19,\n  "type": "get_states"\n}\n```\n\n'
+            "After."
+        )
+
+        result = _sanitize_description(text)
+
+        assert result == "Before.\n\nAfter."
+
+    def test_preserves_non_envelope_json_with_type_field(self) -> None:
+        text = 'Before.\n\n```json\n{\n  "type": "string"\n}\n```\n\nAfter.'
+
+        result = _sanitize_description(text)
+
+        assert '"type": "string"' in result
+        assert result.startswith("Before.")
+        assert result.endswith("After.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/hamster_mcp/mcp/_tests/test_docs_enrichment.py
+++ b/src/hamster_mcp/mcp/_tests/test_docs_enrichment.py
@@ -256,6 +256,85 @@ class TestParseWebsocketDocs:
         result = parse_websocket_docs(md)
         assert "get_states" in result
         assert "dump of all states" in result["get_states"]
+        assert '"type": "get_states"' not in result["get_states"]
+        assert '"type": "result"' not in result["get_states"]
+
+    def test_removes_request_response_and_event_payload_examples(self) -> None:
+        md = (
+            "## Subscribe to events\n\n"
+            "Subscribe to all events.\n\n"
+            '```json\n{\n  "id": 18,\n  "type": "subscribe_events"\n}\n```\n\n'
+            "The server responds with success.\n\n"
+            '```json\n{\n  "id": 18,\n  "type": "result",\n'
+            '  "success": true\n}\n```\n\n'
+            "Events are forwarded after subscribing.\n\n"
+            '```json\n{\n  "id": 18,\n  "type": "event",\n'
+            '  "event": {"event_type": "state_changed"}\n}\n```\n'
+        )
+
+        result = parse_websocket_docs(md)
+
+        assert result == {
+            "subscribe_events": (
+                "Subscribe to all events.\n\n"
+                "The server responds with success.\n\n"
+                "Events are forwarded after subscribing."
+            ),
+        }
+
+    def test_preserves_surrounding_prose_tables_and_non_payload_code(self) -> None:
+        md = (
+            "## Calling a service\n\n"
+            "Calls a service.\n\n"
+            "| Key | Description |\n"
+            "| --- | --- |\n"
+            "| domain | Service domain. |\n\n"
+            '```json\n{\n  "id": 24,\n  "type": "call_service",\n'
+            '  "domain": "light"\n}\n```\n\n'
+            "Useful selector-like object example:\n\n"
+            '```json\n{\n  "entity_id": "light.kitchen"\n}\n```\n'
+        )
+
+        result = parse_websocket_docs(md)
+
+        description = result["call_service"]
+        assert "Calls a service" in description
+        assert "| domain | Service domain. |" in description
+        assert "Useful selector-like object example" in description
+        assert '"entity_id": "light.kitchen"' in description
+        assert '"type": "call_service"' not in description
+
+    def test_extracts_command_type_from_original_raw_payload(self) -> None:
+        md = (
+            "## Calling a service\n\n"
+            "Calls a service with optional data.\n\n"
+            "```json\n{\n"
+            '  "id": 24,\n'
+            '  "type": "call_service",\n'
+            '  "domain": "light",\n'
+            '  "service": "turn_on"\n'
+            "  // Optional service data\n"
+            '  "service_data": {}\n'
+            "}\n```\n"
+        )
+
+        result = parse_websocket_docs(md)
+
+        assert result == {"call_service": "Calls a service with optional data."}
+
+    def test_request_only_subsection_falls_back_to_parent_prose(self) -> None:
+        md = (
+            "## Calling a service\n\n"
+            "Calls a service.\n\n"
+            "### Request\n\n"
+            '```json\n{\n  "id": 24,\n  "type": "call_service"\n}\n```\n\n'
+            "### Response\n\n"
+            '```json\n{\n  "id": 24,\n  "type": "result"\n}\n```\n'
+        )
+
+        result = parse_websocket_docs(md)
+
+        assert result == {"call_service": "Calls a service."}
 
     def test_excludes_non_command_sections(self) -> None:
         md = (


### PR DESCRIPTION
## Summary

- Strip raw Home Assistant WebSocket payload examples from imported command descriptions.
- Preserve surrounding prose, tables, and non-payload code blocks.
- Keep command type extraction based on the original markdown and fall back to parent prose for request-only subsections.

Closes #175

## Verification

- `mise exec -- pytest src/hamster_mcp/mcp/_tests/test_docs_enrichment.py`
- `mise exec -- ruff format --check .`
- `mise exec -- ruff check .`
- `mise exec -- mypy`
- `mise exec -- pytest src/`
