### PR TITLE
Release v0.2.2

### DIFF
--- a/custom_components/hamster_mcp/manifest.json
+++ b/custom_components/hamster_mcp/manifest.json
@@ -10,8 +10,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/altendky/hamster-mcp/issues",
   "requirements": [
-    "hamster-mcp@git+https://github.com/altendky/hamster-mcp.git@main"
+    "hamster-mcp@git+https://github.com/altendky/hamster-mcp.git@v0.2.2"
   ],
   "single_config_entry": true,
-  "version": "0.2.2.dev0"
+  "version": "0.2.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hamster-mcp"
-version = "0.2.2.dev0"
+version = "0.2.2"
 description = "Full AI debugging and maintenance access to your Home Assistant via MCP"
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1713,7 +1713,7 @@ wheels = [
 
 [[package]]
 name = "hamster-mcp"
-version = "0.2.2.dev0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp", version = "3.11.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13.2'" },


### PR DESCRIPTION
Bump version to `0.2.2` and pin requirements to `@v0.2.2`.